### PR TITLE
Load disclaimer modal dynamically

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,6 @@ import { loadView } from "./viewManager.js";
 import { nostrClient } from "./nostr.js";
 import { torrentClient } from "./webtorrent.js";
 import { isDevMode } from "./config.js";
-import disclaimerModal from "./disclaimer.js";
 import { isWhitelistEnabled } from "./config.js";
 import {
   initialWhitelist,
@@ -208,9 +207,8 @@ class bitvidApp {
         }
       }
 
-      // 5. Setup general event listeners, show disclaimers
+      // 5. Setup general event listeners
       this.setupEventListeners();
-      disclaimerModal.show();
 
       // 6) Load the default view ONLY if there's no #view= already
       if (!window.location.hash || !window.location.hash.startsWith("#view=")) {

--- a/js/disclaimer.js
+++ b/js/disclaimer.js
@@ -2,17 +2,29 @@
 
 class DisclaimerModal {
   constructor() {
-    // Initialize elements when the disclaimer HTML is in the DOM.
-    this.init();
+    this.modal = null;
+    this.acceptButton = null;
+    this.acceptHandler = null;
   }
 
   init() {
     this.modal = document.getElementById("disclaimerModal");
-    this.acceptButton = document.getElementById("acceptDisclaimer");
-    if (this.acceptButton) {
-      this.acceptButton.addEventListener("click", () => {
+    const nextAcceptButton = document.getElementById("acceptDisclaimer");
+
+    if (!this.acceptHandler) {
+      this.acceptHandler = () => {
         this.hide();
-      });
+      };
+    }
+
+    if (this.acceptButton && this.acceptHandler) {
+      this.acceptButton.removeEventListener("click", this.acceptHandler);
+    }
+
+    this.acceptButton = nextAcceptButton || null;
+
+    if (this.acceptButton && this.acceptHandler) {
+      this.acceptButton.addEventListener("click", this.acceptHandler);
     }
   }
 

--- a/js/index.js
+++ b/js/index.js
@@ -171,6 +171,12 @@ Promise.all([
 
     // Also run once on initial load
     handleHashChange();
+
+    return import("./disclaimer.js");
+  })
+  .then(({ default: disclaimerModal }) => {
+    disclaimerModal.init();
+    disclaimerModal.show();
   });
 
 /* -------------------------------------------


### PR DESCRIPTION
## Summary
- dynamically import the disclaimer modal only after its HTML is inserted into the DOM
- update the disclaimer modal helper to cache DOM references safely across repeated init calls
- remove the eager disclaimer modal invocation from app initialization so the new flow controls first-run display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d0aff309c8832bb546df31ffe0b931