### PR TITLE
Support URL-first playback with torrent fallback

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -331,6 +331,9 @@ async function loadUserVideos(pubkey) {
         "duration-300"
       );
 
+      const encodedUrl = encodeURIComponent(video.url || "");
+      const encodedMagnet = encodeURIComponent(video.magnet || "");
+
       cardEl.innerHTML = `
         <div class="cursor-pointer relative group">
           <div class="ratio-16-9">
@@ -345,7 +348,9 @@ async function loadUserVideos(pubkey) {
           <div>
             <h3
               class="text-lg font-bold text-white mb-2 line-clamp-2"
-              data-play-magnet="${encodeURIComponent(video.magnet)}"
+              data-video-id="${video.id}"
+              data-play-url="${encodedUrl}"
+              data-play-magnet="${encodedMagnet}"
             >
               ${safeTitle}
             </h3>
@@ -453,13 +458,15 @@ function localConvertEventToVideo(event) {
   try {
     const content = JSON.parse(event.content || "{}");
     const isSupportedVersion = content.version >= 2;
-    const hasRequiredFields = !!(content.title && content.magnet);
+    const hasRequiredFields = !!(
+      content.title && (content.url || content.magnet)
+    );
 
     if (!isSupportedVersion) {
       return { id: event.id, invalid: true, reason: "version <2" };
     }
     if (!hasRequiredFields) {
-      return { id: event.id, invalid: true, reason: "missing title/magnet" };
+      return { id: event.id, invalid: true, reason: "missing title/url+magnet" };
     }
 
     return {
@@ -468,6 +475,7 @@ function localConvertEventToVideo(event) {
       version: content.version,
       isPrivate: content.isPrivate ?? false,
       title: content.title ?? "",
+      url: content.url ?? "",
       magnet: content.magnet ?? "",
       thumbnail: content.thumbnail ?? "",
       description: content.description ?? "",

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -329,11 +329,15 @@ class SubscriptionsManager {
 
       const safeTitle = window.app?.escapeHTML(video.title) || "Untitled";
       const safeThumb = window.app?.escapeHTML(video.thumbnail) || "";
+      const encodedMagnet = encodeURIComponent(video.magnet || "");
+      const encodedUrl = encodeURIComponent(video.url || "");
       const cardHtml = `
         <div class="video-card bg-gray-900 rounded-lg overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 ${highlightClass}">
           <a
             href="${shareUrl}"
-            data-play-magnet="${encodeURIComponent(video.magnet)}"
+            data-video-id="${video.id}"
+            data-play-url="${encodedUrl}"
+            data-play-magnet="${encodedMagnet}"
             class="block cursor-pointer relative group"
           >
             <div class="ratio-16-9">
@@ -347,7 +351,9 @@ class SubscriptionsManager {
           <div class="p-4">
             <h3
               class="text-lg font-bold text-white line-clamp-2 hover:text-blue-400 cursor-pointer mb-3"
-              data-play-magnet="${encodeURIComponent(video.magnet)}"
+              data-video-id="${video.id}"
+              data-play-url="${encodedUrl}"
+              data-play-magnet="${encodedMagnet}"
             >
               ${safeTitle}
             </h3>
@@ -482,7 +488,9 @@ class SubscriptionsManager {
   convertEventToVideo(evt) {
     try {
       const content = JSON.parse(evt.content || "{}");
-      const hasFields = !!(content.title && content.magnet);
+      const hasFields = !!(
+        content.title && (content.url || content.magnet)
+      );
       const versionOk = content.version >= 2;
       if (!versionOk || !hasFields) {
         return { id: evt.id, invalid: true };
@@ -496,6 +504,7 @@ class SubscriptionsManager {
         deleted: content.deleted === true,
         isPrivate: content.isPrivate === true,
         title: content.title || "",
+        url: content.url || "",
         magnet: content.magnet || "",
         thumbnail: content.thumbnail || "",
         description: content.description || "",


### PR DESCRIPTION
## Summary
- relax Nostr video validation to require a title plus either a URL or magnet, propagate the URL through publish/edit/revert flows, and store it on converted events
- update the home feed and supporting views to expose data-video-id/url attributes, capture editable URLs, and disable magnet-only affordances when none exist
- teach the modal player to prefer HTTP playback, fall back to WebTorrent when needed, and guard torrent status UI when no magnet is provided

## Testing
- not run (project does not include automated tests)


------
https://chatgpt.com/codex/tasks/task_b_68d16a1628e8832bbf5d29dbe34ad930