### PR TITLE
Add URL-aware playback delegation with fallback handling

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -240,6 +240,11 @@ async function loadUserVideos(pubkey) {
     const fragment = document.createDocumentFragment();
     const allKnownEventsArray = Array.from(nostrClient.allEvents.values());
 
+    const encodeDataValue = (value) =>
+      typeof value === "string" && value.length > 0
+        ? encodeURIComponent(value)
+        : "";
+
     videos.forEach((video, index) => {
       // Decrypt if user owns a private video
       if (
@@ -331,11 +336,18 @@ async function loadUserVideos(pubkey) {
         "duration-300"
       );
 
-      const encodedUrl = encodeURIComponent(video.url || "");
-      const encodedMagnet = encodeURIComponent(video.magnet || "");
+      const encodedUrl = encodeDataValue(video.url);
+      const encodedMagnet = encodeDataValue(video.magnet);
+      const rawUrl = typeof video.url === "string" ? video.url : "";
+      const rawMagnet = typeof video.magnet === "string" ? video.magnet : "";
 
       cardEl.innerHTML = `
-        <div class="cursor-pointer relative group">
+        <div
+          class="cursor-pointer relative group"
+          data-video-id="${video.id}"
+          data-play-url="${encodedUrl}"
+          data-play-magnet="${encodedMagnet}"
+        >
           <div class="ratio-16-9">
             <img
               src="${fallbackThumb}"
@@ -364,7 +376,11 @@ async function loadUserVideos(pubkey) {
 
       // Clicking the card => open the video modal
       cardEl.addEventListener("click", () => {
-        app.playVideoByEventId(video.id);
+        app.playVideoWithFallback({
+          eventId: video.id,
+          url: rawUrl,
+          magnet: rawMagnet,
+        });
       });
 
       fragment.appendChild(cardEl);

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -250,6 +250,11 @@ class SubscriptionsManager {
     // Only declare localAuthorSet once
     const localAuthorSet = new Set();
 
+    const encodeDataValue = (value) =>
+      typeof value === "string" && value.length > 0
+        ? encodeURIComponent(value)
+        : "";
+
     videos.forEach((video, index) => {
       if (!video.id || !video.title) {
         console.error("Missing ID or title:", video);
@@ -329,8 +334,8 @@ class SubscriptionsManager {
 
       const safeTitle = window.app?.escapeHTML(video.title) || "Untitled";
       const safeThumb = window.app?.escapeHTML(video.thumbnail) || "";
-      const encodedMagnet = encodeURIComponent(video.magnet || "");
-      const encodedUrl = encodeURIComponent(video.url || "");
+      const encodedMagnet = encodeDataValue(video.magnet);
+      const encodedUrl = encodeDataValue(video.url);
       const cardHtml = `
         <div class="video-card bg-gray-900 rounded-lg overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 ${highlightClass}">
           <a


### PR DESCRIPTION
## Summary
- safely encode video URL and magnet data attributes across feed, subscriptions, and channel profile cards
- route card interactions through a new `playVideoWithFallback` helper that tries HTTP playback before WebTorrent fallback
- update event delegation so clicks decode stored attributes and use the unified fallback-aware player

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68d17502b41c832ba2ef02aebe5b3927