### PR TITLE
Ensure video list modal handler persists across view swaps

### DIFF
--- a/js/viewManager.js
+++ b/js/viewManager.js
@@ -44,6 +44,9 @@ export const viewInitRegistry = {
   "most-recent-videos": () => {
     if (window.app && window.app.loadVideos) {
       window.app.videoList = document.getElementById("videoList");
+      if (window.app.attachVideoListHandler) {
+        window.app.attachVideoListHandler();
+      }
       window.app.loadVideos();
     }
     // Force profile updates after the new view is in place.


### PR DESCRIPTION
## Summary
- extract the video list click delegation into a reusable attachment helper
- rebind the handler whenever the main grid is created during init and view reloads to preserve modal playback

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68d19f8e5758832bae622964ce751009