### PR TITLE
Seed subscription videos map and reuse playback handler

### DIFF
--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -261,6 +261,10 @@ class SubscriptionsManager {
         return;
       }
 
+      // Keep the global videos map up to date so delegated playback handlers
+      // can reuse the already fetched metadata for this event.
+      window.app?.videosMap?.set(video.id, video);
+
       localAuthorSet.add(video.pubkey);
 
       const nevent = window.NostrTools.nip19.neventEncode({ id: video.id });
@@ -397,6 +401,11 @@ class SubscriptionsManager {
     });
 
     container.appendChild(fragment);
+
+    if (window.app) {
+      window.app.videoList = container;
+      window.app.attachVideoListHandler?.();
+    }
 
     // Lazy-load
     const lazyEls = container.querySelectorAll("[data-lazy]");


### PR DESCRIPTION
## Summary
- store subscription feed entries in the shared `videosMap` before rendering cards
- hook the subscriptions container into the global delegated click handler for playback reuse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d29f15d0b0832bb90fd40b3c7189b7