### PR TITLE
Add magnet normalization helper and tests

### DIFF
--- a/js/magnetUtils.js
+++ b/js/magnetUtils.js
@@ -1,0 +1,213 @@
+// js/magnetUtils.js
+
+export const DEFAULT_WSS_TRACKERS = [
+  "wss://tracker.openwebtorrent.com",
+  "wss://tracker.btorrent.xyz",
+  "wss://tracker.fastcast.nz",
+];
+
+const HEX_INFO_HASH = /^[0-9a-f]{40}$/i;
+const BTIH_PREFIX = "urn:btih:";
+const ENCODED_BTih_PATTERN = /xt=urn%3Abtih%3A([0-9a-z]+)/gi;
+
+function normalizeForComparison(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    const parsed = new URL(trimmed);
+    const pathname = parsed.pathname.replace(/\/?$/, "");
+    const normalizedPath = pathname ? pathname : "";
+    return (
+      `${parsed.protocol}//${parsed.host}${normalizedPath}${parsed.search}${parsed.hash}`
+        .trim()
+        .toLowerCase()
+    );
+  } catch (err) {
+    return trimmed.replace(/\/?$/, "").toLowerCase();
+  }
+}
+
+function sanitizeHttpUrl(candidate) {
+  if (typeof candidate !== "string") {
+    return "";
+  }
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch (err) {
+    return "";
+  }
+  return "";
+}
+
+export function normalizeAndAugmentMagnet(
+  rawValue,
+  {
+    webSeed,
+    torrentUrl,
+    xs,
+    extraTrackers = [],
+    logger,
+    appProtocol,
+  } = {}
+) {
+  const log = typeof logger === "function" ? logger : () => {};
+  const initial = typeof rawValue === "string" ? rawValue.trim() : "";
+  if (!initial) {
+    return { magnet: "", didChange: false };
+  }
+
+  let working = initial;
+  let didMutate = false;
+  const bareHashMatch = HEX_INFO_HASH.test(working);
+  if (bareHashMatch) {
+    working = `magnet:?xt=${BTIH_PREFIX}${working.toLowerCase()}`;
+    didMutate = true;
+  }
+
+  const decodedXt = working.replace(ENCODED_BTih_PATTERN, (_, hash) => {
+    didMutate = true;
+    return `xt=${BTIH_PREFIX}${hash}`;
+  });
+  working = decodedXt;
+
+  let parsed;
+  try {
+    parsed = new URL(working);
+  } catch (err) {
+    return {
+      magnet: working,
+      didChange: didMutate || working !== initial,
+    };
+  }
+
+  if (parsed.protocol !== "magnet:") {
+    return {
+      magnet: working,
+      didChange: didMutate || working !== initial,
+    };
+  }
+
+  const torrentHint = typeof torrentUrl === "string" && torrentUrl.trim()
+    ? torrentUrl
+    : typeof xs === "string"
+      ? xs.trim()
+      : "";
+
+  const safeTorrentHint = sanitizeHttpUrl(torrentHint);
+  const seedInputs = Array.isArray(webSeed)
+    ? webSeed
+    : typeof webSeed === "string"
+      ? [webSeed]
+      : [];
+
+  const resolvedProtocol = typeof appProtocol === "string" && appProtocol
+    ? appProtocol.toLowerCase()
+    : typeof window !== "undefined" && window.location && window.location.protocol
+      ? window.location.protocol.toLowerCase()
+      : "https:";
+
+  const existingTrackers = new Set(
+    parsed.searchParams
+      .getAll("tr")
+      .map((value) => normalizeForComparison(value))
+      .filter(Boolean)
+  );
+
+  const trackerCandidates = [
+    ...DEFAULT_WSS_TRACKERS,
+    ...extraTrackers,
+  ];
+
+  for (const tracker of trackerCandidates) {
+    if (typeof tracker !== "string") {
+      continue;
+    }
+    const trimmedTracker = tracker.trim();
+    if (!trimmedTracker) {
+      continue;
+    }
+    if (!/^wss:\/\//i.test(trimmedTracker)) {
+      continue;
+    }
+    const normalizedTracker = normalizeForComparison(trimmedTracker);
+    if (!normalizedTracker || existingTrackers.has(normalizedTracker)) {
+      continue;
+    }
+    parsed.searchParams.append("tr", trimmedTracker);
+    existingTrackers.add(normalizedTracker);
+    didMutate = true;
+  }
+
+  if (safeTorrentHint) {
+    const existingXs = new Set(
+      parsed.searchParams
+        .getAll("xs")
+        .map((value) => normalizeForComparison(value))
+        .filter(Boolean)
+    );
+    const normalizedXs = normalizeForComparison(safeTorrentHint);
+    if (normalizedXs && !existingXs.has(normalizedXs)) {
+      parsed.searchParams.append("xs", safeTorrentHint);
+      didMutate = true;
+    }
+  }
+
+  if (seedInputs.length) {
+    const existingWs = new Set(
+      parsed.searchParams
+        .getAll("ws")
+        .map((value) => normalizeForComparison(value))
+        .filter(Boolean)
+    );
+    for (const seedInput of seedInputs) {
+      if (typeof seedInput !== "string") {
+        continue;
+      }
+      const trimmedSeed = seedInput.trim();
+      if (!trimmedSeed) {
+        continue;
+      }
+      try {
+        const parsedSeed = new URL(trimmedSeed);
+        const seedProtocol = parsedSeed.protocol;
+        const allowHttpSeed = resolvedProtocol === "http:";
+        if (
+          seedProtocol === "https:" ||
+          (seedProtocol === "http:" && allowHttpSeed)
+        ) {
+          const seedValue = parsedSeed.toString();
+          const normalizedSeed = normalizeForComparison(seedValue);
+          if (normalizedSeed && !existingWs.has(normalizedSeed)) {
+            parsed.searchParams.append("ws", seedValue);
+            existingWs.add(normalizedSeed);
+            didMutate = true;
+          }
+        } else if (seedProtocol === "http:") {
+          log(
+            `[normalizeAndAugmentMagnet] Skipping insecure web seed: ${trimmedSeed}`
+          );
+        }
+      } catch (err) {
+        // Ignore invalid web seed values silently.
+      }
+    }
+  }
+
+  const finalMagnet = parsed.toString();
+  return {
+    magnet: finalMagnet,
+    didChange: didMutate || finalMagnet !== initial,
+  };
+}

--- a/tests/magnet-utils.test.mjs
+++ b/tests/magnet-utils.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_WSS_TRACKERS,
+  normalizeAndAugmentMagnet,
+} from "../js/magnetUtils.js";
+
+function getParamValues(magnet, key) {
+  const parsed = new URL(magnet);
+  return parsed.searchParams.getAll(key);
+}
+
+(function testBareInfoHashNormalization() {
+  const infoHash = "0123456789abcdef0123456789abcdef01234567";
+  const result = normalizeAndAugmentMagnet(infoHash);
+  assert.ok(result.didChange, "Bare info hash should mark didChange true");
+  const xtValues = getParamValues(result.magnet, "xt");
+  assert.deepEqual(xtValues, [`urn:btih:${infoHash}`]);
+  const trackerValues = getParamValues(result.magnet, "tr");
+  for (const tracker of DEFAULT_WSS_TRACKERS) {
+    assert.ok(
+      trackerValues.includes(tracker),
+      `Expected tracker ${tracker} to be appended`
+    );
+  }
+})();
+
+(function testEncodedXtDecoding() {
+  const infoHash = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+  const encodedMagnet = `magnet:?xt=urn%3Abtih%3A${infoHash}&dn=Example`;
+  const result = normalizeAndAugmentMagnet(encodedMagnet);
+  const xtValues = getParamValues(result.magnet, "xt");
+  assert.deepEqual(xtValues, [`urn:btih:${infoHash}`]);
+})();
+
+(function testDuplicateTrackerFiltering() {
+  const infoHash = "fedcba9876543210fedcba9876543210fedcba98";
+  const baseMagnet =
+    `magnet:?xt=urn:btih:${infoHash}` +
+    "&tr=wss://tracker.openwebtorrent.com" +
+    "&tr=WsS://tracker.openwebtorrent.com/" +
+    "&tr=https://not-allowed.example";
+  const result = normalizeAndAugmentMagnet(baseMagnet, {
+    extraTrackers: [
+      "wss://tracker.fastcast.nz",
+      "http://tracker.invalid",
+      "wss://tracker.openwebtorrent.com",
+    ],
+  });
+  const trackers = getParamValues(result.magnet, "tr");
+  const openwebCount = trackers.filter(
+    (value) => value === "wss://tracker.openwebtorrent.com"
+  ).length;
+  assert.equal(openwebCount, 1, "Duplicate WSS tracker should be collapsed");
+  assert.ok(
+    trackers.includes("wss://tracker.fastcast.nz"),
+    "Expected extra WSS tracker to be preserved"
+  );
+  assert.ok(
+    !trackers.includes("http://tracker.invalid"),
+    "Non-WSS tracker candidates should be ignored"
+  );
+})();
+
+(function testWebSeedHandlingWithLogging() {
+  const infoHash = "0123456789abcdef0123456789abcdef01234567";
+  const messages = [];
+  const result = normalizeAndAugmentMagnet(`magnet:?xt=urn:btih:${infoHash}`, {
+    webSeed: [
+      "https://cdn.example.com/video.mp4",
+      "http://cdn.example.com/legacy.mp4",
+      "https://cdn.example.com/video.mp4",
+    ],
+    logger: (msg) => messages.push(msg),
+    appProtocol: "https:",
+  });
+  const seeds = getParamValues(result.magnet, "ws");
+  assert.deepEqual(seeds, ["https://cdn.example.com/video.mp4"]);
+  assert.equal(messages.length, 1, "HTTP seed should have been skipped with a log");
+  assert.ok(
+    messages[0].includes("Skipping insecure web seed"),
+    "Expected skip message for HTTP seed"
+  );
+})();
+
+(function testHttpWebSeedAllowedOnHttpOrigin() {
+  const infoHash = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+  const result = normalizeAndAugmentMagnet(`magnet:?xt=urn:btih:${infoHash}`, {
+    webSeed: "http://cdn.example.com/video.mp4",
+    appProtocol: "http:",
+  });
+  const seeds = getParamValues(result.magnet, "ws");
+  assert.deepEqual(seeds, ["http://cdn.example.com/video.mp4"]);
+})();
+
+console.log("magnet-utils tests passed");


### PR DESCRIPTION
## Summary
- add a shared magnet normalization helper that canonicalizes hashes, fixes encoded xt values, enforces WSS trackers, and gates web seeds
- integrate the new helper into upload and playback flows with fallback retry logic for untouched magnet strings
- add unit coverage for bare hashes, encoded magnets, web seed filtering, and duplicate tracker handling

## Testing
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d2c54d038c832bb6386d7048aabbd2