### PR TITLE
Handle legacy video notes and fix magnet encoding

### DIFF
--- a/js/magnetUtils.js
+++ b/js/magnetUtils.js
@@ -205,7 +205,16 @@ export function normalizeAndAugmentMagnet(
     }
   }
 
-  const finalMagnet = parsed.toString();
+  let finalMagnet = parsed.toString();
+  const decodedFinalMagnet = finalMagnet.replace(
+    ENCODED_BTih_PATTERN,
+    (_, hash) => `xt=${BTIH_PREFIX}${hash}`
+  );
+  if (decodedFinalMagnet !== finalMagnet) {
+    finalMagnet = decodedFinalMagnet;
+    didMutate = true;
+  }
+
   return {
     magnet: finalMagnet,
     didChange: didMutate || finalMagnet !== initial,

--- a/js/videoEventUtils.js
+++ b/js/videoEventUtils.js
@@ -7,6 +7,73 @@
 const MAGNET_URI_PATTERN = /^magnet:\?/i;
 const HEX_INFO_HASH_PATTERN = /\b[0-9a-f]{40}\b/gi;
 
+function safeTrim(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function pickFirstString(values = []) {
+  if (!Array.isArray(values)) {
+    return "";
+  }
+
+  for (const value of values) {
+    const trimmed = safeTrim(value);
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return "";
+}
+
+export function deriveTitleFromEvent({
+  parsedContent = {},
+  tags = [],
+  primaryTitle = "",
+} = {}) {
+  const initial = safeTrim(primaryTitle);
+  if (initial) {
+    return initial;
+  }
+
+  const directCandidates = pickFirstString([
+    parsedContent?.title,
+    parsedContent?.name,
+    parsedContent?.filename,
+    parsedContent?.fileName,
+    parsedContent?.subject,
+    parsedContent?.caption,
+  ]);
+  if (directCandidates) {
+    return directCandidates;
+  }
+
+  const metaTitle = safeTrim(parsedContent?.meta?.title);
+  if (metaTitle) {
+    return metaTitle;
+  }
+
+  if (Array.isArray(tags)) {
+    for (const tag of tags) {
+      if (!Array.isArray(tag) || tag.length < 2) {
+        continue;
+      }
+      const key = safeTrim(tag[0]).toLowerCase();
+      if (!key) {
+        continue;
+      }
+      if (["title", "subject", "caption", "name"].includes(key)) {
+        const candidate = safeTrim(tag[1]);
+        if (candidate) {
+          return candidate;
+        }
+      }
+    }
+  }
+
+  return "";
+}
+
 function extractInfoHashesFromString(value, pushInfoHash) {
   if (typeof value !== "string") {
     return;

--- a/tests/legacy-infohash.test.mjs
+++ b/tests/legacy-infohash.test.mjs
@@ -64,6 +64,23 @@ const LEGACY_INFO_HASH = "0123456789abcdef0123456789abcdef01234567";
   assert.equal(video.rawMagnet, "");
 })();
 
+(function testLegacyEventWithoutTitleStillLoads() {
+  const event = {
+    id: "evt-no-title",
+    pubkey: "pk2",
+    created_at: 2,
+    tags: [],
+    content: JSON.stringify({
+      version: 1,
+      magnet: `magnet:?xt=urn:btih:${LEGACY_INFO_HASH}`,
+    }),
+  };
+
+  const video = convertEventToVideo(event);
+  assert.equal(video.invalid, false, "Legacy events without title should fallback");
+  assert.ok(video.title && video.title.length > 0, "Fallback title should be provided");
+})();
+
 (function testPlaybackConfigNormalizesInfoHash() {
   const result = deriveTorrentPlaybackConfig({
     magnet: "",


### PR DESCRIPTION
## Summary
- add shared title derivation logic so legacy Bitvid events without modern metadata still render
- update home/subscriptions/channel converters to accept <v2 magnet/info-hash payloads and provide fallbacks
- prevent magnet augmentation from percent-encoding the btih urn for WebTorrent
- extend the legacy infohash test to cover missing-title compatibility

## Testing
- node tests/legacy-infohash.test.mjs
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d2dacebe7c832b8cc1683d686c2004