### PR TITLE
Decode magnet URIs before torrent playback

### DIFF
--- a/js/magnetUtils.js
+++ b/js/magnetUtils.js
@@ -51,6 +51,38 @@ function sanitizeHttpUrl(candidate) {
   return "";
 }
 
+export function safeDecodeMagnet(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  let decoded = value.trim();
+  if (!decoded) {
+    return "";
+  }
+
+  for (let i = 0; i < 2; i += 1) {
+    if (!decoded.includes("%")) {
+      break;
+    }
+
+    try {
+      const candidate = decodeURIComponent(decoded);
+      if (!candidate) {
+        break;
+      }
+      if (candidate === decoded) {
+        break;
+      }
+      decoded = candidate.trim();
+    } catch (err) {
+      break;
+    }
+  }
+
+  return decoded;
+}
+
 export function normalizeAndAugmentMagnet(
   rawValue,
   {

--- a/tests/legacy-infohash.test.mjs
+++ b/tests/legacy-infohash.test.mjs
@@ -96,4 +96,25 @@ const LEGACY_INFO_HASH = "0123456789abcdef0123456789abcdef01234567";
   assert.equal(result.provided, true);
 })();
 
+(function testPlaybackConfigDecodesEncodedMagnet() {
+  const rawMagnet =
+    `magnet:?xt=urn:btih:${LEGACY_INFO_HASH}&dn=Legacy+Example`;
+  const encodedMagnet = encodeURIComponent(rawMagnet);
+  const result = deriveTorrentPlaybackConfig({
+    magnet: encodedMagnet,
+    infoHash: "",
+    url: "",
+  });
+
+  assert.ok(result.magnet.startsWith("magnet:?"));
+  const parsed = new URL(result.magnet);
+  assert.equal(
+    parsed.searchParams.get("xt"),
+    `urn:btih:${LEGACY_INFO_HASH}`,
+    "Expected encoded magnet to be normalized"
+  );
+  assert.equal(result.provided, true);
+  assert.equal(result.usedInfoHash, false);
+})();
+
 console.log("legacy infohash tests passed");

--- a/tests/magnet-utils.test.mjs
+++ b/tests/magnet-utils.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   DEFAULT_WSS_TRACKERS,
   normalizeAndAugmentMagnet,
+  safeDecodeMagnet,
 } from "../js/magnetUtils.js";
 
 function getParamValues(magnet, key) {
@@ -90,6 +91,27 @@ function getParamValues(magnet, key) {
   });
   const seeds = getParamValues(result.magnet, "ws");
   assert.deepEqual(seeds, ["http://cdn.example.com/video.mp4"]);
+})();
+
+(function testSafeDecodeMagnetHandlesEncodedValues() {
+  const rawMagnet =
+    "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=Example";
+  const encodedMagnet = encodeURIComponent(rawMagnet);
+  assert.equal(
+    safeDecodeMagnet(encodedMagnet),
+    rawMagnet,
+    "Expected percent-encoded magnet to be decoded"
+  );
+})();
+
+(function testSafeDecodeMagnetLeavesPlainStringsUntouched() {
+  const rawMagnet =
+    "magnet:?xt=urn:btih:abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+  assert.equal(
+    safeDecodeMagnet(rawMagnet),
+    rawMagnet,
+    "Plain magnet strings should pass through unchanged"
+  );
 })();
 
 console.log("magnet-utils tests passed");


### PR DESCRIPTION
## Summary
- decode magnet strings with percent-encoded characters before validation and playback
- share a safeDecodeMagnet helper across playback logic to keep copied magnets usable
- add regression coverage for encoded magnets in magnet utils and playback config tests

## Testing
- node tests/magnet-utils.test.mjs
- node tests/legacy-infohash.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d2e2645dac832bb81b0c284dadc3a2