### PR TITLE
Fix encoded magnet playback and surface legacy notes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -716,7 +716,7 @@ class bitvidApp {
             return decodeURIComponent(value);
           } catch (err) {
             console.warn("Failed to decode data attribute:", err);
-            return "";
+            return value;
           }
         };
 
@@ -724,7 +724,8 @@ class bitvidApp {
         const encodedMagnet = trigger.getAttribute("data-play-magnet") || "";
 
         const url = decodeDataValue(encodedUrl);
-        const magnet = decodeDataValue(encodedMagnet);
+        const rawMagnet = decodeDataValue(encodedMagnet);
+        const magnet = safeDecodeMagnet(rawMagnet) || rawMagnet;
         const eventId = trigger.getAttribute("data-video-id");
 
         if (eventId) {

--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -490,7 +490,15 @@ function localConvertEventToVideo(event) {
   const trimmedMagnet = typeof magnet === "string" ? magnet.trim() : "";
   const trimmedInfoHash = typeof infoHash === "string" ? infoHash.trim() : "";
   const playbackMagnet = trimmedMagnet || trimmedInfoHash;
-  const numericVersion = Number.isFinite(version) ? version : 0;
+  const parsedVersion =
+    typeof version === "number"
+      ? version
+      : typeof version === "string"
+        ? Number.parseInt(version, 10)
+        : Number.NaN;
+  const numericVersion = Number.isFinite(parsedVersion)
+    ? parsedVersion
+    : 0;
 
   const hasPlayableSource = Boolean(trimmedUrl) || Boolean(playbackMagnet);
   if (!hasPlayableSource) {

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -518,7 +518,15 @@ class SubscriptionsManager {
     const trimmedMagnet = typeof magnet === "string" ? magnet.trim() : "";
     const trimmedInfoHash = typeof infoHash === "string" ? infoHash.trim() : "";
     const playbackMagnet = trimmedMagnet || trimmedInfoHash;
-    const numericVersion = Number.isFinite(version) ? version : 0;
+    const parsedVersion =
+      typeof version === "number"
+        ? version
+        : typeof version === "string"
+          ? Number.parseInt(version, 10)
+          : Number.NaN;
+    const numericVersion = Number.isFinite(parsedVersion)
+      ? parsedVersion
+      : 0;
 
     const hasPlayableSource = Boolean(trimmedUrl) || Boolean(playbackMagnet);
     if (!hasPlayableSource) {


### PR DESCRIPTION
## Summary
- make the delegated click handler resilient to percent-encoded magnet attributes before handing off to playback
- parse version strings in channel and subscriptions views so legacy magnet-only posts are kept instead of being marked invalid

## Testing
- node tests/magnet-utils.test.mjs
- node tests/legacy-infohash.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d3fb07b5e8832b8571f21b9de17035