### PR TITLE
Fix magnet handling and legacy magnet fallback

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -5,6 +5,7 @@ import { accessControl } from "./accessControl.js";
 import {
   deriveTitleFromEvent,
   parseVideoEventPayload,
+  findLegacyMagnetInEvent,
 } from "./videoEventUtils.js";
 
 /**
@@ -106,8 +107,12 @@ function convertEventToVideo(event) {
 
   const trimmedUrl = typeof url === "string" ? url.trim() : "";
   const trimmedMagnet = typeof magnet === "string" ? magnet.trim() : "";
+  const legacyMagnet = findLegacyMagnetInEvent(event);
+  const trimmedLegacyMagnet =
+    typeof legacyMagnet === "string" ? legacyMagnet.trim() : "";
   const trimmedInfoHash = typeof infoHash === "string" ? infoHash.trim() : "";
-  const playbackMagnet = trimmedMagnet || trimmedInfoHash;
+  const playbackMagnet =
+    trimmedMagnet || trimmedLegacyMagnet || trimmedInfoHash;
 
   const numericVersion = Number.isFinite(version) ? version : 0;
   const hasPlayableSource = Boolean(trimmedUrl) || Boolean(playbackMagnet);
@@ -148,7 +153,7 @@ function convertEventToVideo(event) {
     title: resolvedTitle,
     url: trimmedUrl,
     magnet: playbackMagnet,
-    rawMagnet: trimmedMagnet,
+    rawMagnet: trimmedMagnet || trimmedLegacyMagnet,
     infoHash: trimmedInfoHash,
     thumbnail: parsedContent.thumbnail ?? "",
     description: parsedContent.description ?? "",


### PR DESCRIPTION
## Summary
- store raw playback URLs and magnets on rendered cards instead of percent-encoding so playback receives an intact magnet string
- decode dataset values safely before starting playback and share the raw values across the home feed, subscriptions, and channel profiles
- expand the video conversion helpers to recover magnets from legacy events and accept them as playable sources

## Testing
- node tests/magnet-utils.test.mjs
- node tests/legacy-infohash.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d419434f3c832b8dfd1e23b9d0bedf