### PR TITLE
Fix legacy WebTorrent magnet playback and refresh agent guidance

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2042,15 +2042,20 @@ class bitvidApp {
         );
       }
 
-      let cacheBustedMagnet = trimmedCandidate;
-      try {
-        const parsed = new URL(trimmedCandidate);
-        parsed.searchParams.set("ts", Date.now().toString());
-        cacheBustedMagnet = parsed.toString();
-      } catch (err) {
-        const separator = trimmedCandidate.includes("?") ? "&" : "?";
-        cacheBustedMagnet = `${trimmedCandidate}${separator}ts=${Date.now()}`;
+      const timestamp = Date.now().toString();
+      const [magnetPrefix, magnetQuery = ""] = trimmedCandidate.split("?", 2);
+      let normalizedMagnet = magnetPrefix;
+      let queryParts = magnetQuery
+        .split("&")
+        .map((part) => part.trim())
+        .filter((part) => part && !/^ts=\d+$/.test(part));
+
+      if (queryParts.length) {
+        normalizedMagnet = `${magnetPrefix}?${queryParts.join("&")}`;
       }
+
+      const separator = normalizedMagnet.includes("?") ? "&" : "?";
+      const cacheBustedMagnet = `${normalizedMagnet}${separator}ts=${timestamp}`;
 
       await torrentClient.cleanup();
       this.resetTorrentStats();


### PR DESCRIPTION
## Summary
- stop `playViaWebTorrent` from running magnets through `new URL()` when cache-busting and strip any stale `ts` params before appending a fresh timestamp
- rework `normalizeAndAugmentMagnet` to preserve raw magnet payloads while appending browser-safe trackers, torrent hints, and HTTPS web seeds without re-encoding
- refresh `AGENTS.md` with the legacy compatibility lessons, raw magnet markup guidance, and the safe normalization helper

## Testing
- node tests/magnet-utils.test.mjs
- node tests/legacy-infohash.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d4232af098832b8c7d876621904472