### PR TITLE
Ensure video thumbnails fallback to default image

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -110,12 +110,27 @@ class MediaLoader {
                 "";
 
               const applyFallback = () => {
-                if (!fallbackSrc) {
+                const resolvedFallback =
+                  fallbackSrc && fallbackSrc.trim()
+                    ? fallbackSrc.trim()
+                    : FALLBACK_THUMBNAIL_SRC;
+
+                if (!resolvedFallback) {
                   return;
                 }
-                if (el.src !== fallbackSrc) {
-                  el.src = fallbackSrc;
+
+                if (el.src !== resolvedFallback) {
+                  el.src = resolvedFallback;
                 }
+
+                if (!el.dataset.fallbackSrc) {
+                  el.dataset.fallbackSrc = resolvedFallback;
+                }
+
+                if (!el.getAttribute("data-fallback-src")) {
+                  el.setAttribute("data-fallback-src", resolvedFallback);
+                }
+
                 el.dataset.thumbnailFailed = "true";
               };
 


### PR DESCRIPTION
## Summary
- ensure the lazy loader always resolves a fallback thumbnail when a remote cover fails
- persist the resolved fallback on the element so subsequent loads reuse the default cover

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d432a76454832ba18c4e3aeedabcd9