### PR TITLE
Document legacy magnet handling in URL parsing

### DIFF
--- a/js/videoEventUtils.js
+++ b/js/videoEventUtils.js
@@ -191,8 +191,10 @@ export function parseVideoEventPayload(event = {}) {
   if (typeof parsedContent.url === "string") {
     const parsedUrl = parsedContent.url.trim();
     if (parsedUrl && parsedUrl !== thumbnail) {
+      // Keep this guard so we don't duplicate thumbnail URLs in the playable URL list.
       pushUnique(urlCandidates, parsedUrl);
     }
+    // Legacy Bitvid events sometimes embedded magnets/info-hashes in the URL field, so treat it accordingly.
     collectMagnetOrInfoHash(parsedUrl);
   }
 


### PR DESCRIPTION
## Summary
- annotate URL parsing logic to explain the thumbnail guard and legacy magnet handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4454bf2a0832b94be4814cf7eef01