### PR TITLE
Document Chrome CORS pruning workaround

### DIFF
--- a/js/webtorrent.js
+++ b/js/webtorrent.js
@@ -173,6 +173,8 @@ export class TorrentClient {
 
   // Handle Chrome-based browsers
   handleChromeTorrent(torrent, videoElement, resolve, reject) {
+    // Prune demo web seeds/trackers that chronically trip Chromium CORS and
+    // deliberately mutate `torrent._opts` as a sanctioned WebTorrent workaround.
     torrent.on("warning", (err) => {
       if (err && typeof err.message === "string") {
         if (


### PR DESCRIPTION
## Summary
- document why the Chrome warning handler prunes specific demo web seeds and trackers
- note that mutating `torrent._opts` is an intentional WebTorrent workaround

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d446d6b64c832b8e5a206b39d349b7