### PR TITLE
Document intentional post-parsing data-play assignments

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -382,6 +382,9 @@ async function loadUserVideos(pubkey) {
         </div>
       `;
 
+      // Leave the data-play-* attributes empty in the template markup so the raw
+      // URL/magnet strings can be assigned after parsing without HTML entity
+      // escaping, keeping this renderer consistent with app.js.
       const interactiveEls = cardEl.querySelectorAll("[data-video-id]");
       interactiveEls.forEach((el) => {
         if (!el.dataset) return;

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -400,6 +400,9 @@ class SubscriptionsManager {
       t.innerHTML = cardHtml.trim();
       const cardEl = t.content.firstElementChild;
       if (cardEl) {
+        // Leave the data-play-* attributes empty in the literal markup so we can
+        // assign the raw URL/magnet strings post-parsing without HTML entity
+        // escaping, mirroring the approach in app.js.
         const interactiveEls = cardEl.querySelectorAll("[data-video-id]");
         interactiveEls.forEach((el) => {
           if (!el.dataset) return;


### PR DESCRIPTION
## Summary
- document why subscription card templates leave data-play-* attributes blank before assigning dataset values
- add the same explanatory comment to the channel profile renderer to keep the pattern obvious

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d44e8631b8832ba0abf2dc88a3ae04