### PR TITLE
Document autoplay flags in torrent handlers

### DIFF
--- a/js/webtorrent.js
+++ b/js/webtorrent.js
@@ -213,6 +213,7 @@ export class TorrentClient {
       return reject(new Error("No compatible video file found in torrent"));
     }
 
+    // Satisfy autoplay requirements and keep cross-origin chunks usable (e.g., for snapshots).
     videoElement.muted = true;
     videoElement.crossOrigin = "anonymous";
 
@@ -250,6 +251,7 @@ export class TorrentClient {
       return reject(new Error("No compatible video file found in torrent"));
     }
 
+    // Satisfy autoplay requirements and keep cross-origin chunks usable (e.g., for snapshots).
     videoElement.muted = true;
     videoElement.crossOrigin = "anonymous";
 


### PR DESCRIPTION
## Summary
- explain why the muted and crossOrigin flags are set in both Chrome and Firefox torrent handlers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4504bc5bc832b8b9fab8a49822b7b