### PR TITLE
Document probeUrl HEAD and range fallback

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2118,6 +2118,13 @@ class bitvidApp {
     }
   }
 
+  /**
+   * HEAD first avoids downloading bytes when probing, but many hosts reject
+   * HEAD or omit `Accept-Ranges`, so we fall back to a tiny `Range:
+   * bytes=0-1023` GET and only warn when range headers are missing. This
+   * fallback prevents false "unplayable" results and should stay paired with
+   * the HEAD logic unless a new probe keeps both paths in sync.
+   */
   async probeUrl(url) {
     const trimmed = typeof url === "string" ? url.trim() : "";
     if (!trimmed) {


### PR DESCRIPTION
## Summary
- document why probeUrl issues a HEAD request before falling back to a ranged GET
- call out the regression risk if the HEAD and GET probe paths ever diverge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d45206beb8832b874fd43bea9e1f0a