### PR TITLE
Add documentation for relay readiness probe

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -220,6 +220,11 @@ class NostrClient {
     }
   }
 
+  // We subscribe to kind `0` purely as a liveness probe because almost every
+  // relay can answer it quickly. Either an `event` or `eose` signals success,
+  // while the 5s timer guards against relays that never respond. We immediately
+  // `unsub` to avoid leaking subscriptions. Note: any future change must still
+  // provide a lightweight readiness check with similar timeout semantics.
   async connectToRelays() {
     return Promise.all(
       this.relays.map(


### PR DESCRIPTION
## Summary
- document why the temporary kind-0 subscription exists in `connectToRelays`
- clarify success signals, timeout guard, and the need to immediately unsubscribe
- note that future changes must keep a lightweight readiness check with similar timeout semantics

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d45348bc14832bb69d21fcbf16a8c7