### PR TITLE
Add magnet normalization helper and update upload flow

### DIFF
--- a/js/magnet.js
+++ b/js/magnet.js
@@ -1,0 +1,19 @@
+import { WSS_TRACKERS } from "./constants.js";
+import { normalizeAndAugmentMagnet as normalizeLegacy } from "./magnetUtils.js";
+
+export function normalizeAndAugmentMagnet(rawValue, { ws = "", xs = "" } = {}) {
+  const trimmedInput = typeof rawValue === "string" ? rawValue.trim() : "";
+  const trimmedWs = typeof ws === "string" ? ws.trim() : "";
+  const trimmedXs = typeof xs === "string" ? xs.trim() : "";
+
+  const webSeeds = trimmedWs ? [trimmedWs] : [];
+
+  const result = normalizeLegacy(trimmedInput, {
+    webSeed: webSeeds,
+    torrentUrl: trimmedXs,
+    xs: trimmedXs,
+    extraTrackers: WSS_TRACKERS,
+  });
+
+  return result.magnet;
+}


### PR DESCRIPTION
## Summary
- add a lightweight magnet normalization helper that augments ws/xs hints while ensuring tracker coverage
- require title plus either a URL or magnet in the upload form and normalize magnets via the new helper
- extend magnet utility tests to cover the new helper behaviour

## Testing
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d455557ec4832bbe45c97dfdb2a2f0