### PR TITLE
Fix WebTorrent controller claim race

### DIFF
--- a/sw.min.js
+++ b/sw.min.js
@@ -15,6 +15,9 @@
           Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)))
         );
     }
+    if (event.data && event.data.type === "ENSURE_CLIENTS_CLAIM") {
+      event.waitUntil(clients.claim());
+    }
   });
 
   // Immediately install and skip waiting


### PR DESCRIPTION
## Summary
- proactively prod the active service worker to claim clients before starting WebTorrent playback
- harden the controller wait by polling, retrying claims, and reusing the new helper when reinitializing the torrent client
- let the worker respond to ENSURE_CLIENTS_CLAIM messages so playback can recover from slow Chromium claim hand-offs

## Testing
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d4954cf8f8832bb03681155aad6fed