### PR TITLE
Update video converter and publishing schema

### DIFF
--- a/tests/legacy-infohash.test.mjs
+++ b/tests/legacy-infohash.test.mjs
@@ -44,7 +44,7 @@ const LEGACY_INFO_HASH = "0123456789abcdef0123456789abcdef01234567";
   assert.equal(parsed.infoHash, LEGACY_INFO_HASH);
 })();
 
-(function testConvertTreatsInfoHashAsPlayable() {
+(function testConvertFlagsBareInfoHashAsInvalid() {
   const event = {
     id: "evt-convert",
     pubkey: "pk",
@@ -58,10 +58,8 @@ const LEGACY_INFO_HASH = "0123456789abcdef0123456789abcdef01234567";
   };
 
   const video = convertEventToVideo(event);
-  assert.equal(video.invalid, false, "Legacy info hash events should not be dropped");
-  assert.equal(video.magnet, LEGACY_INFO_HASH);
-  assert.equal(video.infoHash, LEGACY_INFO_HASH);
-  assert.equal(video.rawMagnet, "");
+  assert.equal(video.invalid, true, "Bare info-hash payloads should be flagged");
+  assert.equal(video.reason, "missing playable source");
 })();
 
 (function testLegacyEventWithoutTitleStillLoads() {


### PR DESCRIPTION
## Summary
- rework nostr video converter to defensively parse content, recover legacy magnets, and gate legacy helpers with ACCEPT_LEGACY_V1
- ensure published events always include url and magnet fields in spec order alongside existing metadata
- update legacy info-hash tests to reflect the new invalid handling for notes without playable sources

## Testing
- node tests/legacy-infohash.test.mjs
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d498995ce8832b87b0fcb6b093297a