### PR TITLE
Fix playback data encoding for cards

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -382,11 +382,14 @@ async function loadUserVideos(pubkey) {
 
       // Leave the data-play-* attributes empty in the template markup so the raw
       // URL/magnet strings can be assigned after parsing without HTML entity
-      // escaping, keeping this renderer consistent with app.js.
+      // escaping, keeping this renderer consistent with app.js. The stored URL is
+      // encoded so it stays intact within data-* attributes, and the click
+      // handler decodes it while leaving magnets untouched until
+      // safeDecodeMagnet() runs.
       const interactiveEls = cardEl.querySelectorAll("[data-video-id]");
       interactiveEls.forEach((el) => {
         if (!el.dataset) return;
-        el.dataset.playUrl = playbackUrl || "";
+        el.dataset.playUrl = encodeURIComponent(playbackUrl || "");
         el.dataset.playMagnet = playbackMagnet || "";
       });
 

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -408,11 +408,13 @@ class SubscriptionsManager {
       if (cardEl) {
         // Leave the data-play-* attributes empty in the literal markup so we can
         // assign the raw URL/magnet strings post-parsing without HTML entity
-        // escaping, mirroring the approach in app.js.
+        // escaping, mirroring the approach in app.js. The URL is encoded so that
+        // special characters survive storage in data-* attributes; the click
+        // handler decodes it right before playback while keeping the magnet raw.
         const interactiveEls = cardEl.querySelectorAll("[data-video-id]");
         interactiveEls.forEach((el) => {
           if (!el.dataset) return;
-          el.dataset.playUrl = playbackUrl || "";
+          el.dataset.playUrl = encodeURIComponent(playbackUrl || "");
           el.dataset.playMagnet = playbackMagnet || "";
         });
       }


### PR DESCRIPTION
## Summary
- URL-encode data-play-url attributes while storing raw magnets on home, channel, and subscription cards
- Decode card URLs in the delegated click handler and feed unencoded magnets through the existing safeDecodeMagnet flow

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d49b2e7378832bbe30347e7c135183