### PR TITLE
Add cached CDN health badges to video cards

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -345,7 +345,11 @@ async function loadUserVideos(pubkey) {
       const magnetCandidate = trimmedMagnet || legacyInfoHash;
       const playbackUrl =
         typeof video.url === "string" ? video.url : "";
+      const trimmedUrl = playbackUrl ? playbackUrl.trim() : "";
       const playbackMagnet = magnetCandidate || "";
+      const urlStatusHtml = trimmedUrl
+        ? app.getUrlHealthPlaceholderMarkup()
+        : "";
 
       cardEl.innerHTML = `
         <div
@@ -362,21 +366,24 @@ async function loadUserVideos(pubkey) {
             />
           </div>
         </div>
-        <div class="p-4 flex items-center justify-between">
-          <div>
-            <h3
-              class="text-lg font-bold text-white mb-2 line-clamp-2"
-              data-video-id="${video.id}"
-              data-play-url=""
-              data-play-magnet=""
-            >
-              ${safeTitle}
-            </h3>
-            <p class="text-sm text-gray-500">
-              ${new Date(video.created_at * 1000).toLocaleString()}
-            </p>
+        <div class="p-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <h3
+                class="text-lg font-bold text-white mb-2 line-clamp-2"
+                data-video-id="${video.id}"
+                data-play-url=""
+                data-play-magnet=""
+              >
+                ${safeTitle}
+              </h3>
+              <p class="text-sm text-gray-500">
+                ${new Date(video.created_at * 1000).toLocaleString()}
+              </p>
+            </div>
+            ${gearMenu}
           </div>
-          ${gearMenu}
+          ${urlStatusHtml}
         </div>
       `;
 
@@ -392,6 +399,17 @@ async function loadUserVideos(pubkey) {
         el.dataset.playUrl = encodeURIComponent(playbackUrl || "");
         el.dataset.playMagnet = playbackMagnet || "";
       });
+
+      if (trimmedUrl) {
+        const badgeEl = cardEl.querySelector("[data-url-health-state]");
+        if (badgeEl) {
+          app.handleUrlHealthBadge({
+            video,
+            url: trimmedUrl,
+            badgeEl,
+          });
+        }
+      }
 
       fragment.appendChild(cardEl);
     });

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -348,6 +348,10 @@ class SubscriptionsManager {
         typeof video.url === "string" ? video.url : "";
       const playbackMagnet =
         typeof video.magnet === "string" ? video.magnet : "";
+      const trimmedUrl = playbackUrl ? playbackUrl.trim() : "";
+      const urlStatusHtml = trimmedUrl
+        ? window.app?.getUrlHealthPlaceholderMarkup?.() ?? ""
+        : "";
       const cardHtml = `
         <div class="video-card bg-gray-900 rounded-lg overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 ${highlightClass}">
           <a
@@ -398,6 +402,7 @@ class SubscriptionsManager {
               </div>
               ${gearMenu}
             </div>
+            ${urlStatusHtml}
           </div>
         </div>
       `;
@@ -417,6 +422,17 @@ class SubscriptionsManager {
           el.dataset.playUrl = encodeURIComponent(playbackUrl || "");
           el.dataset.playMagnet = playbackMagnet || "";
         });
+
+        if (trimmedUrl && window.app?.handleUrlHealthBadge) {
+          const badgeEl = cardEl.querySelector("[data-url-health-state]");
+          if (badgeEl) {
+            window.app.handleUrlHealthBadge({
+              video,
+              url: trimmedUrl,
+              badgeEl,
+            });
+          }
+        }
       }
       fragment.appendChild(cardEl);
     });


### PR DESCRIPTION
## Summary
- add a short-lived URL health cache with helper utilities in `app.js`
- surface hosted URL health badges on home, channel, and subscription cards with cached probes
- reuse shared badge markup and avoid duplicate probes by tracking in-flight checks

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68d49e473be4832b9fe9005628f6bb7e