### PR TITLE
Normalize video version parsing

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -263,15 +263,10 @@ function convertEventToVideo(event = {}) {
     return { id: event.id, invalid: true, reason };
   }
 
-  const rawVersion = parsedContent.version;
-  let version = 0;
-  if (typeof rawVersion === "number" && Number.isFinite(rawVersion)) {
-    version = rawVersion;
-  } else if (typeof rawVersion === "string") {
-    const parsedVersion = Number(rawVersion);
-    if (Number.isFinite(parsedVersion)) {
-      version = parsedVersion;
-    }
+  const rawVersion = parsedContent.version ?? 1;
+  let version = Number(rawVersion);
+  if (!Number.isFinite(version)) {
+    version = 1;
   }
 
   return {


### PR DESCRIPTION
## Summary
- default video conversion to treat missing or invalid version fields as v1 so legacy magnet-only events remain playable

## Testing
- node tests/legacy-infohash.test.mjs
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68d51b0f9f58832b9fe3001d106f7bd1