### PR TITLE
Fix playback dataset handling for raw magnets

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -984,7 +984,7 @@ class bitvidApp {
 
     const handler = async (event) => {
       const trigger = event.target.closest(
-        "[data-play-url], [data-play-magnet]"
+        "[data-play-magnet],[data-play-url]"
       );
       if (!trigger) {
         return;
@@ -1012,13 +1012,13 @@ class bitvidApp {
           }
         }
 
-        const magnet = safeDecodeMagnet(rawMagnetValue) || rawMagnetValue;
+        const magnet = typeof rawMagnetValue === "string" ? rawMagnetValue : "";
         const eventId = trigger.getAttribute("data-video-id");
 
         if (eventId) {
           await this.playVideoByEventId(eventId);
         } else {
-          await this.playVideoWithoutEvent({ url, magnet });
+          await this.playVideoWithFallback({ url, magnet });
         }
       }
     };

--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -338,15 +338,14 @@ async function loadUserVideos(pubkey) {
         "duration-300"
       );
 
-      const trimmedMagnet =
-        typeof video.magnet === "string" ? video.magnet.trim() : "";
+      const rawMagnet =
+        typeof video.magnet === "string" ? video.magnet : "";
       const legacyInfoHash =
         typeof video.infoHash === "string" ? video.infoHash.trim() : "";
-      const magnetCandidate = trimmedMagnet || legacyInfoHash;
       const playbackUrl =
         typeof video.url === "string" ? video.url : "";
       const trimmedUrl = playbackUrl ? playbackUrl.trim() : "";
-      const playbackMagnet = magnetCandidate || "";
+      const playbackMagnet = rawMagnet || legacyInfoHash || "";
       const urlStatusHtml = trimmedUrl
         ? app.getUrlHealthPlaceholderMarkup()
         : "";
@@ -396,7 +395,13 @@ async function loadUserVideos(pubkey) {
       const interactiveEls = cardEl.querySelectorAll("[data-video-id]");
       interactiveEls.forEach((el) => {
         if (!el.dataset) return;
-        el.dataset.playUrl = encodeURIComponent(playbackUrl || "");
+
+        if (trimmedUrl) {
+          el.dataset.playUrl = encodeURIComponent(trimmedUrl);
+        } else {
+          delete el.dataset.playUrl;
+        }
+
         el.dataset.playMagnet = playbackMagnet || "";
       });
 

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -419,7 +419,13 @@ class SubscriptionsManager {
         const interactiveEls = cardEl.querySelectorAll("[data-video-id]");
         interactiveEls.forEach((el) => {
           if (!el.dataset) return;
-          el.dataset.playUrl = encodeURIComponent(playbackUrl || "");
+
+          if (trimmedUrl) {
+            el.dataset.playUrl = encodeURIComponent(trimmedUrl);
+          } else {
+            delete el.dataset.playUrl;
+          }
+
           el.dataset.playMagnet = playbackMagnet || "";
         });
 


### PR DESCRIPTION
## Summary
- stop percent-encoding magnets in subscription and channel cards while only attaching encoded URLs when present
- update the delegated playback handler to read raw magnet values, decode optional URLs, and invoke the URL-first fallback flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d51f1049fc832bb92d012a0b0a0fb2