### PR TITLE
Improve URL health caching and cleanup flows

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -209,7 +209,7 @@ async function loadUserVideos(pubkey) {
     }
 
     // 4) Deduplicate older overshadowed versions => newest only
-    videos = dedupeToNewestByRoot(videos);
+    videos = app?.dedupeVideosByRoot?.(videos) ?? dedupeToNewestByRoot(videos);
 
     // 5) Filter out blacklisted IDs / authors
     videos = videos.filter((video) => {

--- a/js/nostr.js
+++ b/js/nostr.js
@@ -959,6 +959,23 @@ class NostrClient {
     });
 
     // Return the subscription object if you need to unsub manually later
+    const originalUnsub =
+      typeof sub.unsub === "function" ? sub.unsub.bind(sub) : () => {};
+    let unsubscribed = false;
+    sub.unsub = () => {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+      clearInterval(processInterval);
+      try {
+        return originalUnsub();
+      } catch (err) {
+        console.error("[subscribeVideos] Failed to unsub from pool:", err);
+        return undefined;
+      }
+    };
+
     return sub;
   }
 


### PR DESCRIPTION
## Summary
- persist URL health probes in localStorage with a 45 minute TTL and reuse cached results to surface CDN offline badges across views
- normalize share links, guard modal injection, and fix login/logout plus cleanup handling so subscriptions, observers, and intervals are released safely
- dedupe subscription/channel renders by root event and reuse the new absolute share URLs when building cards

## Testing
- No automated tests were run (project does not include a test suite)

------
https://chatgpt.com/codex/tasks/task_b_68d523e453ec832b8f29406d42273f30