### PR TITLE
Add hosted URL workflow with WebTorrent fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,4 +70,15 @@ Document the run in PR descriptions so QA can cross-reference results.
 * **Probing:** Lightweight `HEAD`/`GET` requests should back `probeUrl()` so dead URLs can be hidden or flagged without blocking the UI.
 * **Extensibility:** Future work (live streams, NIP-96 uploads, analytics) should preserve the URL-first strategy and magnet safety rules above.
 
+---
+
+## 7. Content Schema v3 & Playback Rules
+
+* **Event payloads:** New video notes serialize as version `3` with the JSON shape:
+  `{ "version": 3, "title": string, "url"?: string, "magnet"?: string, "thumbnail"?: string, "description"?: string, "mode": "live"|"dev", "isPrivate": boolean, "deleted": boolean, "videoRootId": string }`.
+* **Validation:** Every note must include a non-empty `title` plus at least one playable source (`url` or `magnet`). URL-only and magnet-only posts are both valid. Legacy v2 magnet notes stay readable.
+* **Upload UX:** The modal collects a hosted HTTPS URL and/or magnet. Enforce HTTPS for direct playback while keeping magnets optional when a URL is supplied.
+* **Playback orchestration:** `playVideoWithFallback` probes and plays the HTTPS URL first, watches for stalls/errors, and then falls back to WebTorrent. When both sources exist, pass the hosted URL through to WebTorrent as a webseed hint.
+* **Status messaging:** Update modal copy to reflect whether playback is direct or via P2P so regressions surface quickly during QA.
+
 **End of AGENTS.md**

--- a/components/upload-modal.html
+++ b/components/upload-modal.html
@@ -70,13 +70,21 @@
           </div>
 
           <!-- Hosted video URL -->
-          <div class="mb-4">
-            <label for="uploadUrl" class="block text-sm font-medium">Hosted video URL</label>
+          <div class="form-group">
+            <label
+              for="uploadUrl"
+              class="block text-sm font-medium text-gray-200"
+              >Hosted video URL (https)</label
+            >
             <input
               id="uploadUrl"
               type="url"
-              class="w-full p-2 rounded"
-              placeholder="https://cdn.example.com/video.mp4 or .webm/.m3u8"
+              class="mt-1 block w-full rounded-md border-gray-700 bg-gray-800 text-gray-100 focus:border-blue-500 focus:ring-blue-500"
+              placeholder="https://cdn.example.com/video.mp4"
+            />
+            <small class="mt-1 block text-xs text-gray-400"
+              >Optional but preferred. We will play this first and fall back to
+              P2P.</small
             >
           </div>
 
@@ -109,7 +117,8 @@
               class="mt-1 block w-full rounded-md border border-gray-700 bg-gray-800 text-gray-100 focus:border-blue-500 focus:ring-blue-500"
             />
             <p class="mt-1 text-xs text-gray-400">
-              Include this when you have a torrent source. Bitvid will automatically augment it with any web seeds or metadata you provide.
+              Provide a hosted URL for instant playback. Add a magnet for P2P
+              cost control.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- add a hosted HTTPS URL field to the upload modal and relax magnet validation so either source is accepted
- publish v3 video notes that include optional URL metadata and document the new schema for agents
- orchestrate playback to probe HTTPS first, attach watchdogs, and fall back to WebTorrent with optional webseed hints

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d533a9a218832bbf89794f9e487a70