### PR TITLE
Restore Umami automatic tracking

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -74,8 +74,7 @@ export function ensureAnalyticsLoaded(doc = typeof document !== "undefined" ? do
   script.src = ANALYTICS_CONFIG.scriptSrc;
   script.setAttribute(SCRIPT_ATTR, SCRIPT_IDENTIFIER);
   script.dataset.websiteId = ANALYTICS_CONFIG.websiteId;
-  // 🔧 merged conflicting changes from codex/add-tracking-script-to-all-pages vs unstable
-  script.dataset.autoTrack = "false";
+  // Allow Umami to handle automatic pageview tracking by default.
   script.addEventListener("load", () => {
     scriptLoadedOnce = true;
     flushPendingCalls();


### PR DESCRIPTION
## Summary
- remove the `data-auto-track="false"` override so Umami can emit automatic pageview events again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d55ef105f8832bb6b73631f8e117c7