### PR TITLE
Reduce thumbnail flicker and avoid modal tracking duplicates

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -10,9 +10,14 @@ async function loadModal(url) {
       throw new Error("Failed to load " + url);
     }
     const html = await response.text();
+    // Remove analytics loader tags from modal partials to avoid duplicate pageview events.
+    const sanitizedHtml = html.replace(
+      /<script\b[^>]*src=["'][^"']*tracking\.js[^"']*["'][^>]*>\s*<\/script>/gi,
+      ""
+    );
     document
       .getElementById("modalContainer")
-      .insertAdjacentHTML("beforeend", html);
+      .insertAdjacentHTML("beforeend", sanitizedHtml);
     console.log(url, "loaded");
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- cache the rendered video list signature so repeated nostr updates do not thrash thumbnails
- reset the cached signature when reloading or swapping the list element to keep feeds fresh
- strip tracking.js tags when injecting modal HTML to avoid duplicate analytics events inside modals

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d566dee6e4832b824c523962ca8974