### PR TITLE
Improve thumbnail caching and skip tracking script in partials

### DIFF
--- a/js/viewManager.js
+++ b/js/viewManager.js
@@ -2,6 +2,8 @@
 import { initChannelProfileView } from "./channelProfile.js";
 import { subscriptions } from "./subscriptions.js";
 
+const TRACKING_SCRIPT_PATTERN = /(?:^|\/)tracking\.js(?:$|\?)/;
+
 /**
  * Load a partial view by URL into the #viewContainer.
  */
@@ -23,6 +25,10 @@ export async function loadView(viewUrl) {
     // Copy and execute any inline scripts
     const scriptTags = doc.querySelectorAll("script");
     scriptTags.forEach((oldScript) => {
+      const src = oldScript.getAttribute("src") || "";
+      if (src && TRACKING_SCRIPT_PATTERN.test(src)) {
+        return;
+      }
       const newScript = document.createElement("script");
       Array.from(oldScript.attributes).forEach((attr) => {
         newScript.setAttribute(attr.name, attr.value);


### PR DESCRIPTION
## Summary
- cache successfully loaded video thumbnails so re-renders reuse the remote image instead of flashing the fallback
- clean up the cached thumbnail map when cards disappear and wire load/error hooks to keep it in sync
- strip tracking.js references when loading modals or views so analytics only boots once per page

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d56d78a52c832bbae571e42abd2aaa