### PR TITLE
Speed up modal open animations

### DIFF
--- a/components/upload-modal.html
+++ b/components/upload-modal.html
@@ -24,7 +24,7 @@
     >
       <!-- Top Bar (similar to video-modal) -->
       <div
-        class="sticky top-0 bg-gradient-to-b from-black/80 to-transparent transition-transform duration-300 p-4 flex items-center justify-between"
+        class="sticky top-0 bg-gradient-to-b from-black/80 to-transparent transition-transform duration-150 p-4 flex items-center justify-between"
       >
         <h2 class="text-xl font-bold text-white">Share a Video</h2>
         <button

--- a/components/video-modal.html
+++ b/components/video-modal.html
@@ -9,7 +9,7 @@
       <!-- Navigation bar - sliding at top -->
       <div
         id="modalNav"
-        class="sticky top-0 z-60 bg-gradient-to-b from-black/80 to-transparent transition-transform duration-300"
+        class="sticky top-0 z-60 bg-gradient-to-b from-black/80 to-transparent transition-transform duration-150"
       >
         <div class="flex items-center px-6 py-4">
           <button

--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,7 @@
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+  --modal-motion-duration: 160ms;
 }
 
 /* Core Styles */
@@ -137,7 +138,7 @@ header img {
   display: flex;
   flex-direction: column;
   background-color: #0f172a;
-  animation: fadeIn 0.3s ease-in-out;
+  animation: fadeIn var(--modal-motion-duration) ease-out;
 }
 
 @keyframes fadeIn {
@@ -148,6 +149,12 @@ header img {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-content {
+    animation-duration: 1ms;
   }
 }
 


### PR DESCRIPTION
## Summary
- shorten the modal fade-in animation and expose a CSS variable so dialogs appear faster while staying themeable
- add a reduced-motion safeguard and trim the video/upload modal header transition so overlays feel more responsive

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_b_68d579671840832b84db563b3879fb40