### PR TITLE
Improve thumbnail caching and fade-in

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -90,10 +90,28 @@ header img {
   }
 }
 
+[data-video-thumbnail][data-thumbnail-loaded="true"] {
+  animation: video-thumbnail-fade-in 220ms ease-out forwards;
+}
+
+@keyframes video-thumbnail-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .video-card--enter {
     opacity: 1;
     animation: none;
+  }
+
+  [data-video-thumbnail][data-thumbnail-loaded="true"] {
+    animation: none;
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure feed thumbnails are only cached after the real image loads and track a data attribute to note the loaded state
- clean up thumbnail load/error listeners so cached thumbnails persist across re-renders without getting stuck on fallbacks
- add a thumbnail fade-in animation that respects reduced-motion preferences to match the video card appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d594efa980832ba67b66c80303aace