### PR TITLE
Abort edit flow when prompts are cancelled

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3093,22 +3093,41 @@ class bitvidApp {
 
       // 3) Prompt the user for updated fields
       const newTitle = prompt("New Title? (blank=keep existing)", video.title);
+      if (newTitle === null) {
+        return;
+      }
+
       const newMagnet = prompt(
         "New Magnet? (blank=keep existing)",
         video.magnet
       );
+      if (newMagnet === null) {
+        return;
+      }
+
       const newUrl = prompt(
         "New URL? (blank=keep existing)",
         video.url || ""
       );
+      if (newUrl === null) {
+        return;
+      }
+
       const newThumb = prompt(
         "New Thumbnail? (blank=keep existing)",
         video.thumbnail
       );
+      if (newThumb === null) {
+        return;
+      }
+
       const newDesc = prompt(
         "New Description? (blank=keep existing)",
         video.description
       );
+      if (newDesc === null) {
+        return;
+      }
       // const wantPrivate = confirm("Make this video private? OK=Yes, Cancel=No");
 
       // 4) Build final updated fields (or fallback to existing)


### PR DESCRIPTION
## Summary
- stop the edit flow immediately when any of the edit prompts are cancelled so no updates are published unexpectedly

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68d5b01687c8832baad627b6e9e284ac