### PR TITLE
Ensure url health badges update after mounting

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2153,11 +2153,22 @@ class bitvidApp {
   }
 
   updateUrlHealthBadge(badgeEl, state, videoId) {
-    if (!badgeEl || !badgeEl.isConnected) {
+    if (!badgeEl) {
       return;
     }
 
     if (videoId && badgeEl.dataset.urlHealthFor && badgeEl.dataset.urlHealthFor !== videoId) {
+      return;
+    }
+
+    if (!badgeEl.isConnected) {
+      if (typeof requestAnimationFrame === "function") {
+        requestAnimationFrame(() => {
+          if (badgeEl.isConnected) {
+            this.updateUrlHealthBadge(badgeEl, state, videoId);
+          }
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- schedule url health badge updates to run after the element is attached to the DOM
- ensure cached probe results render correctly in the video grid

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d5bb9e24f8832b90bd84ebf66ee463