### PR TITLE
Handle opaque CDN probes via video fallback

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3476,6 +3476,10 @@ class bitvidApp {
     }
 
     if (response.type === "opaque") {
+      const fallback = await this.probeUrlWithVideoElement(trimmed);
+      if (fallback && fallback.outcome) {
+        return fallback;
+      }
       return { outcome: "opaque" };
     }
 


### PR DESCRIPTION
## Summary
- fall back to a video-element probe when the HEAD request returns an opaque response so cross-origin URLs can be marked healthy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d5c08d8d3c832b942ae8a35dd32b5d