### PR TITLE
Align CDN and torrent badges across video grids

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2241,13 +2241,27 @@ class bitvidApp {
         ? "⚠️ CDN timed out"
         : "Checking hosted URL…");
 
+    const hadMargin = badgeEl.classList.contains("mt-3");
+
     badgeEl.dataset.urlHealthState = status;
     badgeEl.setAttribute("aria-live", "polite");
     badgeEl.setAttribute("role", status === "offline" ? "alert" : "status");
     badgeEl.textContent = message;
 
-    badgeEl.className =
-      "url-health-badge mt-3 text-xs font-semibold px-2 py-1 rounded transition-colors duration-200";
+    const baseClasses = [
+      "url-health-badge",
+      "text-xs",
+      "font-semibold",
+      "px-2",
+      "py-1",
+      "rounded",
+      "transition-colors",
+      "duration-200",
+    ];
+    if (hadMargin) {
+      baseClasses.unshift("mt-3");
+    }
+    badgeEl.className = baseClasses.join(" ");
 
     if (status === "healthy") {
       badgeEl.classList.add(


### PR DESCRIPTION
## Summary
- preserve existing margin settings when updating CDN health badges so they stay aligned with torrent indicators
- normalize channel grid cards to expose magnet metadata, reuse torrent health badges, and attach WebTorrent health checks for consistency with the home feed

## Testing
- `node tests/magnet-utils.test.mjs`
- `node tests/legacy-infohash.test.mjs`


------
https://chatgpt.com/codex/tasks/task_b_68d5d469bd70832ba98d9cb733b3c843