### PR TITLE
Add zap button to video modal

### DIFF
--- a/components/video-modal.html
+++ b/components/video-modal.html
@@ -51,6 +51,19 @@
                 class="icon-image"
               />
             </button>
+            <!-- Zap Button (circular) -->
+            <button
+              id="modalZapBtn"
+              type="button"
+              class="icon-button"
+              aria-label="Send a zap"
+            >
+              <img
+                src="assets/svg/lightning-bolt.svg"
+                alt="Zap"
+                class="icon-image"
+              />
+            </button>
             <!-- Share Button (circular) -->
             <button id="shareBtn" class="icon-button">
               <img

--- a/js/app.js
+++ b/js/app.js
@@ -480,6 +480,7 @@ class bitvidApp {
     this.creatorNpub = null;
     this.copyMagnetBtn = null;
     this.shareBtn = null;
+    this.modalZapBtn = null;
     this.modalPosterCleanup = null;
     this.cleanupPromise = null;
 
@@ -845,6 +846,7 @@ class bitvidApp {
     // Copy/Share buttons
     this.copyMagnetBtn = document.getElementById("copyMagnetBtn") || null;
     this.shareBtn = document.getElementById("shareBtn") || null;
+    this.modalZapBtn = document.getElementById("modalZapBtn") || null;
 
     // Attach existing event listeners for copy/share
     if (this.copyMagnetBtn) {
@@ -867,6 +869,11 @@ class bitvidApp {
           .writeText(shareUrl)
           .then(() => this.showSuccess("Video link copied to clipboard!"))
           .catch(() => this.showError("Failed to copy the link."));
+      });
+    }
+    if (this.modalZapBtn) {
+      this.modalZapBtn.addEventListener("click", () => {
+        window.alert("Zaps coming soon.");
       });
     }
 


### PR DESCRIPTION
## Summary
- add the zap action button to the video modal toolbar beside the copy magnet and share controls
- hook the modal zap button to the existing "Zaps coming soon." placeholder alert

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5da303b64832bb10f6b88d973ce79