### PR TITLE
Add Cloudflare toggle placeholder to upload modal

### DIFF
--- a/components/upload-modal.html
+++ b/components/upload-modal.html
@@ -50,8 +50,34 @@
       </div>
 
       <!-- Form Content -->
-      <div class="p-6 space-y-4">
-        <form id="uploadForm" class="space-y-4">
+      <div class="p-6 space-y-6">
+        <div class="flex justify-center">
+          <div
+            class="inline-flex items-center rounded-full bg-gray-800/80 p-1 text-sm"
+            role="group"
+            aria-label="Upload mode selector"
+          >
+            <button
+              type="button"
+              class="upload-mode-toggle flex-1 rounded-full px-4 py-2 font-medium text-gray-300 transition-colors hover:bg-gray-700/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+              data-upload-mode="custom"
+              aria-pressed="true"
+            >
+              Custom
+            </button>
+            <button
+              type="button"
+              class="upload-mode-toggle flex-1 rounded-full px-4 py-2 font-medium text-gray-300 transition-colors hover:bg-gray-700/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+              data-upload-mode="cloudflare"
+              aria-pressed="false"
+            >
+              Cloudflare
+            </button>
+          </div>
+        </div>
+
+        <div id="customUploadSection">
+          <form id="uploadForm" class="space-y-4">
           <p class="text-sm text-gray-400">
             Share a title plus either a hosted video URL or a magnet link. Providing both helps Bitvid fall back gracefully.
           </p>
@@ -166,6 +192,15 @@
             Publish
           </button>
         </form>
+        </div>
+
+        <div id="cloudflareUploadSection" class="hidden">
+          <div
+            class="flex min-h-[320px] items-center justify-center rounded-lg border border-dashed border-gray-700 bg-black/20 p-8 text-center text-sm text-gray-400"
+          >
+            Cloudflare uploads are coming soon.
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -455,6 +455,10 @@ class bitvidApp {
     this.closeUploadModalBtn =
       document.getElementById("closeUploadModal") || null;
     this.uploadForm = document.getElementById("uploadForm") || null;
+    this.uploadModeToggleButtons = [];
+    this.customUploadSection = null;
+    this.cloudflareUploadSection = null;
+    this.activeUploadMode = "custom";
 
     // Optional small inline player stats
     this.status = document.getElementById("status") || null;
@@ -1041,6 +1045,13 @@ class bitvidApp {
       this.closeUploadModalBtn =
         document.getElementById("closeUploadModal") || null;
       this.uploadForm = document.getElementById("uploadForm") || null;
+      this.uploadModeToggleButtons = Array.from(
+        document.querySelectorAll(".upload-mode-toggle[data-upload-mode]")
+      );
+      this.customUploadSection =
+        document.getElementById("customUploadSection") || null;
+      this.cloudflareUploadSection =
+        document.getElementById("cloudflareUploadSection") || null;
 
       // Optional: if close button found, wire up
       if (this.closeUploadModalBtn) {
@@ -1058,12 +1069,59 @@ class bitvidApp {
         });
       }
 
+      if (this.uploadModeToggleButtons.length > 0) {
+        this.uploadModeToggleButtons.forEach((btn) => {
+          btn.addEventListener("click", () => {
+            const mode = btn.dataset.uploadMode || "custom";
+            this.setUploadMode(mode);
+          });
+        });
+      }
+
+      this.setUploadMode(this.activeUploadMode);
+
       console.log("Upload modal initialization successful");
       return true;
     } catch (error) {
       console.error("initUploadModal failed:", error);
       this.showError(`Failed to initialize upload modal: ${error.message}`);
       return false;
+    }
+  }
+
+  setUploadMode(mode) {
+    const normalized = mode === "cloudflare" ? "cloudflare" : "custom";
+    this.activeUploadMode = normalized;
+
+    if (this.customUploadSection) {
+      if (normalized === "custom") {
+        this.customUploadSection.classList.remove("hidden");
+      } else {
+        this.customUploadSection.classList.add("hidden");
+      }
+    }
+
+    if (this.cloudflareUploadSection) {
+      if (normalized === "cloudflare") {
+        this.cloudflareUploadSection.classList.remove("hidden");
+      } else {
+        this.cloudflareUploadSection.classList.add("hidden");
+      }
+    }
+
+    if (Array.isArray(this.uploadModeToggleButtons)) {
+      this.uploadModeToggleButtons.forEach((btn) => {
+        if (!btn || !btn.dataset) {
+          return;
+        }
+
+        const isActive = btn.dataset.uploadMode === normalized;
+        btn.classList.toggle("bg-blue-500", isActive);
+        btn.classList.toggle("text-white", isActive);
+        btn.classList.toggle("shadow", isActive);
+        btn.classList.toggle("text-gray-300", !isActive);
+        btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- add a Custom/Cloudflare toggle control at the top of the upload modal
- keep the existing upload form under the Custom tab and show a placeholder for the Cloudflare path
- wire the toggle into app.js so the active mode is tracked and buttons update styling/state

## Testing
- manual: opened the upload modal and toggled between Custom and Cloudflare modes

------
https://chatgpt.com/codex/tasks/task_b_68d7136653a0832b95c27cf8d7ea1033