### PR TITLE
Allow manual Cloudflare R2 configuration without API token

### DIFF
--- a/js/storage/r2-s3.js
+++ b/js/storage/r2-s3.js
@@ -1,10 +1,12 @@
 // js/storage/r2-s3.js
 import {
   S3Client,
+  CreateBucketCommand,
   CreateMultipartUploadCommand,
   UploadPartCommand,
   CompleteMultipartUploadCommand,
   AbortMultipartUploadCommand,
+  HeadBucketCommand,
   PutBucketCorsCommand,
 } from "https://esm.sh/@aws-sdk/client-s3@3.637.0?target=es2022&bundle";
 
@@ -42,6 +44,34 @@ export function makeR2Client({ accountId, accessKeyId, secretAccessKey }) {
   });
 }
 
+async function ensureBucketExists({ s3, bucket }) {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    return;
+  } catch (error) {
+    const status = error?.$metadata?.httpStatusCode || 0;
+    const code = error?.name || error?.Code || "";
+    if (status !== 404 && code !== "NotFound" && code !== "NoSuchBucket") {
+      throw error;
+    }
+  }
+
+  try {
+    await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+  } catch (error) {
+    const status = error?.$metadata?.httpStatusCode || 0;
+    const code = error?.name || error?.Code || "";
+    if (
+      status === 409 ||
+      code === "BucketAlreadyOwnedByYou" ||
+      code === "BucketAlreadyExists"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
 export async function ensureBucketCors({ s3, bucket, origins }) {
   if (!s3) {
     throw new Error("S3 client is required to configure CORS");
@@ -54,6 +84,8 @@ export async function ensureBucketCors({ s3, bucket, origins }) {
   if (allowedOrigins.length === 0) {
     return;
   }
+
+  await ensureBucketExists({ s3, bucket });
 
   const command = new PutBucketCorsCommand({
     Bucket: bucket,


### PR DESCRIPTION
## Summary
- allow uploads to proceed when no Cloudflare API token is provided by deriving the bucket name and public domain
- persist the manually configured bucket details in local settings for future uploads
- surface manual status metadata so the UI can warn when using the managed r2.dev domain

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d74f7a7b40832b977f955c0b6f192f