### PR TITLE
Verify CDN badge only marks healthy for playable videos

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -4561,8 +4561,30 @@ class bitvidApp {
       return { outcome: "opaque" };
     }
 
+    if (!response.ok) {
+      const fallback = await this.probeUrlWithVideoElement(trimmed);
+      if (fallback && fallback.outcome) {
+        return fallback;
+      }
+      return {
+        outcome: "bad",
+        status: response.status,
+      };
+    }
+
+    const playbackCheck = await this.probeUrlWithVideoElement(trimmed);
+    if (playbackCheck && playbackCheck.outcome) {
+      if (playbackCheck.outcome === "ok") {
+        return {
+          ...playbackCheck,
+          status: response.status,
+        };
+      }
+      return playbackCheck;
+    }
+
     return {
-      outcome: response.ok ? "ok" : "bad",
+      outcome: "ok",
       status: response.status,
     };
   }

--- a/js/app.js
+++ b/js/app.js
@@ -4834,6 +4834,32 @@ class bitvidApp {
         fallbackStarted = true;
         this.cleanupUrlPlaybackWatchdog();
         cleanupHostedUrlStatusListeners();
+
+        if (videoEl) {
+          try {
+            videoEl.pause();
+          } catch (err) {
+            this.log(
+              "[playVideoWithFallback] Ignoring pause error before torrent fallback:",
+              err
+            );
+          }
+          try {
+            videoEl.removeAttribute("src");
+          } catch (err) {
+            // removeAttribute throws in old browsers when the attribute does not exist
+          }
+          videoEl.src = "";
+          videoEl.srcObject = null;
+          try {
+            videoEl.load();
+          } catch (err) {
+            this.log(
+              "[playVideoWithFallback] Ignoring load error before torrent fallback:",
+              err
+            );
+          }
+        }
         if (!magnetForPlayback) {
           const message =
             "Hosted playback failed and no magnet fallback is available.";


### PR DESCRIPTION
## Summary
- ensure CDN health checks confirm actual playback using a temporary video element
- fall back to the existing video probe when HEAD requests fail or report non-OK responses
- keep the CDN badge red when the CDN asset cannot be loaded despite an accessible URL

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d813656f64832bb77a2a0dfeb5089c