### PR TITLE
Add profile channel link and reset view state between navigations

### DIFF
--- a/components/profile-modal.html
+++ b/components/profile-modal.html
@@ -62,6 +62,13 @@
             Loading...
           </p>
         </div>
+        <a
+          id="profileChannelLink"
+          href="#"
+          class="inline-flex items-center text-sm text-blue-400 hover:text-blue-300 transition-colors hidden"
+        >
+          View your channel
+        </a>
         <p class="text-sm text-gray-400">
           Some future profile details or settings could go here.
         </p>

--- a/js/viewManager.js
+++ b/js/viewManager.js
@@ -9,6 +9,10 @@ const TRACKING_SCRIPT_PATTERN = /(?:^|\/)tracking\.js(?:$|\?)/;
  */
 export async function loadView(viewUrl) {
   try {
+    if (window.app && typeof window.app.prepareForViewLoad === "function") {
+      window.app.prepareForViewLoad();
+    }
+
     const res = await fetch(viewUrl);
     if (!res.ok) {
       throw new Error(`Failed to load view: ${res.status}`);


### PR DESCRIPTION
## Summary
- add a link in the profile modal that opens the logged-in user’s channel view
- reset shared video grid wiring before loading a new view so lists and avatars refresh reliably
- hide and clear the profile channel link when the user logs out

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d889415584832b81e5bd673fcf6c99