### PR TITLE
Add experimental warning to Cloudflare upload mode

### DIFF
--- a/components/upload-modal.html
+++ b/components/upload-modal.html
@@ -295,6 +295,9 @@
 
         <div id="cloudflareUploadSection" class="hidden">
           <div class="space-y-8">
+            <p class="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-300">
+              This feature is experimental and may not be working correctly.
+            </p>
             <section class="rounded-lg border border-gray-800 bg-gray-900/60 p-5">
               <div class="mb-4 flex items-center justify-between">
                 <h3 class="text-lg font-semibold text-gray-100">


### PR DESCRIPTION
## Summary
- highlight the Cloudflare upload mode with a warning banner explaining it is experimental

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d890c510d8832b9dc19f96726ea7a2