### PR TITLE
Refresh login state and stabilize WebTorrent cleanup

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3849,6 +3849,21 @@ class bitvidApp {
 
     this.pubkey = pubkey;
 
+    let reloadScheduled = false;
+    if (saveToStorage) {
+      try {
+        localStorage.setItem("userPubKey", pubkey);
+        reloadScheduled = true;
+      } catch (err) {
+        console.warn("[app.js] Failed to persist pubkey:", err);
+      }
+    }
+
+    if (reloadScheduled) {
+      window.location.reload();
+      return;
+    }
+
     // Hide login button if present
     if (this.loginButton) {
       this.loginButton.classList.add("hidden");
@@ -3876,11 +3891,6 @@ class bitvidApp {
 
     // (Optional) load the user's own Nostr profile
     this.loadOwnProfile(pubkey);
-
-    // Save pubkey locally if requested
-    if (saveToStorage) {
-      localStorage.setItem("userPubKey", pubkey);
-    }
 
     // Refresh the video list so the user sees any private videos, etc.
     await this.loadVideos();


### PR DESCRIPTION
## Summary
- reload the page after manual logins so ownership checks reset with the active profile
- add a timeout-aware destroy helper and reuse it in the torrent cleanup path to prevent hangs between playbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d8a46d5ff0832ba70d8e993f66fd02