### PR TITLE
Allow clearing fields when editing videos

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3698,28 +3698,48 @@ class bitvidApp {
 
     const original = this.activeEditVideo;
 
+    const titleInput = this.editVideoModal.querySelector("#editVideoTitle");
+    const urlInput = this.editVideoModal.querySelector("#editVideoUrl");
+    const magnetInput = this.editVideoModal.querySelector("#editVideoMagnet");
+    const wsInput = this.editVideoModal.querySelector("#editVideoWs");
+    const xsInput = this.editVideoModal.querySelector("#editVideoXs");
+    const thumbnailInput = this.editVideoModal.querySelector(
+      "#editVideoThumbnail"
+    );
+    const descriptionInput = this.editVideoModal.querySelector(
+      "#editVideoDescription"
+    );
+
     const newTitle = fieldValue("editVideoTitle");
     const newUrl = fieldValue("editVideoUrl");
     const newMagnet = fieldValue("editVideoMagnet");
     const newWs = fieldValue("editVideoWs");
     const newXs = fieldValue("editVideoXs");
-    const wsInput = this.editVideoModal.querySelector("#editVideoWs");
-    const xsInput = this.editVideoModal.querySelector("#editVideoXs");
     const newThumbnail = fieldValue("editVideoThumbnail");
     const newDescription = fieldValue("editVideoDescription");
     const commentsEl = this.editVideoModal.querySelector(
       "#editEnableComments"
     );
 
-    const finalTitle = newTitle || original.title || "";
-    const finalUrl = newUrl || original.url || "";
+    const isEditing = (input) => !input || input.readOnly === false;
+
+    const finalTitle = isEditing(titleInput)
+      ? newTitle
+      : original.title || "";
+    const finalUrl = isEditing(urlInput) ? newUrl : original.url || "";
     const shouldUseOriginalWs = wsInput ? wsInput.readOnly !== false : true;
     const shouldUseOriginalXs = xsInput ? xsInput.readOnly !== false : true;
     let finalWs = shouldUseOriginalWs ? original.ws || "" : newWs;
     let finalXs = shouldUseOriginalXs ? original.xs || "" : newXs;
-    let finalMagnet = newMagnet || original.magnet || "";
-    const finalThumbnail = newThumbnail || original.thumbnail || "";
-    const finalDescription = newDescription || original.description || "";
+    let finalMagnet = isEditing(magnetInput)
+      ? newMagnet
+      : original.magnet || "";
+    const finalThumbnail = isEditing(thumbnailInput)
+      ? newThumbnail
+      : original.thumbnail || "";
+    const finalDescription = isEditing(descriptionInput)
+      ? newDescription
+      : original.description || "";
     const originalEnableComments =
       typeof original.enableComments === "boolean"
         ? original.enableComments

--- a/js/app.js
+++ b/js/app.js
@@ -3723,17 +3723,17 @@ class bitvidApp {
 
     const isEditing = (input) => !input || input.readOnly === false;
 
-    const finalTitle = isEditing(titleInput)
-      ? newTitle
-      : original.title || "";
-    const finalUrl = isEditing(urlInput) ? newUrl : original.url || "";
+    const titleWasEdited = isEditing(titleInput);
+    const urlWasEdited = isEditing(urlInput);
+    const magnetWasEdited = isEditing(magnetInput);
+
+    const finalTitle = titleWasEdited ? newTitle : original.title || "";
+    const finalUrl = urlWasEdited ? newUrl : original.url || "";
     const shouldUseOriginalWs = wsInput ? wsInput.readOnly !== false : true;
     const shouldUseOriginalXs = xsInput ? xsInput.readOnly !== false : true;
     let finalWs = shouldUseOriginalWs ? original.ws || "" : newWs;
     let finalXs = shouldUseOriginalXs ? original.xs || "" : newXs;
-    let finalMagnet = isEditing(magnetInput)
-      ? newMagnet
-      : original.magnet || "";
+    let finalMagnet = magnetWasEdited ? newMagnet : original.magnet || "";
     const finalThumbnail = isEditing(thumbnailInput)
       ? newThumbnail
       : original.thumbnail || "";
@@ -3790,6 +3790,8 @@ class bitvidApp {
       xs: finalXs,
       wsEdited: !shouldUseOriginalWs,
       xsEdited: !shouldUseOriginalXs,
+      urlEdited: urlWasEdited,
+      magnetEdited: magnetWasEdited,
       enableComments: finalEnableComments,
     };
 

--- a/js/nostr.js
+++ b/js/nostr.js
@@ -817,17 +817,19 @@ class NostrClient {
     const wantPrivate = updatedData.isPrivate ?? baseEvent.isPrivate ?? false;
 
     // Use the new magnet if provided; otherwise, fall back to the decrypted old magnet
+    const magnetEdited = updatedData.magnetEdited === true;
     const newMagnetValue =
       typeof updatedData.magnet === "string" ? updatedData.magnet.trim() : "";
-    let finalPlainMagnet = newMagnetValue || oldPlainMagnet;
+    let finalPlainMagnet = magnetEdited ? newMagnetValue : oldPlainMagnet;
     let finalMagnet =
       wantPrivate && finalPlainMagnet
         ? fakeEncrypt(finalPlainMagnet)
         : finalPlainMagnet;
 
+    const urlEdited = updatedData.urlEdited === true;
     const newUrlValue =
       typeof updatedData.url === "string" ? updatedData.url.trim() : "";
-    const finalUrl = newUrlValue || oldUrl;
+    const finalUrl = urlEdited ? newUrlValue : oldUrl;
 
     const wsEdited = updatedData.wsEdited === true;
     const xsEdited = updatedData.xsEdited === true;


### PR DESCRIPTION
## Summary
- respect edit-mode fields when determining final payload values
- allow optional fields like hosted URL or thumbnail to be cleared during video edits

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_b_68d8a7ec17b8832bb81de3a5a0a952dd