### PR TITLE
Make BitVid logo link to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,11 +87,17 @@
         </button>
         <!-- Logo -->
         <!-- Logo fades in once on initial load. -->
-        <img
-          src="assets/svg/bitvid-logo-light-mode.svg"
-          alt="BitVid Logo"
-          class="h-16 fade-in fade-in-delay-100"
-        />
+        <a
+          href="index.html"
+          aria-label="Return to the bitvid home page"
+          class="fade-in fade-in-delay-100"
+        >
+          <img
+            src="assets/svg/bitvid-logo-light-mode.svg"
+            alt="BitVid Logo"
+            class="h-16"
+          />
+        </a>
 
         <!-- Buttons on the far right -->
 

--- a/torrent/beacon.html
+++ b/torrent/beacon.html
@@ -44,11 +44,13 @@
     <header class="header-torrent">
       <div class="container">
         <div class="logo-container">
-          <img
-            src="../assets/svg/bitvid-logo-light-mode.svg"
-            alt="bitvid Logo"
-            class="bitvid-logo"
-          />
+          <a href="../index.html" aria-label="Return to the bitvid home page">
+            <img
+              src="../assets/svg/bitvid-logo-light-mode.svg"
+              alt="bitvid Logo"
+              class="bitvid-logo"
+            />
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- wrap the main header logo in a home-page link so users can quickly return to index
- update the beacon client logo to navigate back to the main index page

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_b_68d8acdeedbc832bb4bfcb34fcd83983