### PR TITLE
Clarify admin moderation configuration scaffolding

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -8,8 +8,7 @@ import { app } from "./app.js";
 import { subscriptions } from "./subscriptions.js"; // <-- NEW import
 import { attachHealthBadges } from "./gridHealth.js";
 import { attachUrlHealthBadges } from "./urlHealthObserver.js";
-import { initialBlacklist, initialWhitelist } from "./lists.js";
-import { isWhitelistEnabled } from "./config.js";
+import { accessControl } from "./accessControl.js";
 
 let cachedZapButton = null;
 
@@ -280,10 +279,7 @@ async function loadUserVideos(pubkey) {
 
       // Author-level
       const authorNpub = app.safeEncodeNpub(video.pubkey) || video.pubkey;
-      if (initialBlacklist.includes(authorNpub)) return false;
-      if (isWhitelistEnabled && !initialWhitelist.includes(authorNpub)) {
-        return false;
-      }
+      if (!accessControl.canAccess(authorNpub)) return false;
       return true;
     });
 

--- a/js/config.js
+++ b/js/config.js
@@ -2,3 +2,19 @@
 
 export const isDevMode = true; // Set to false for production
 export const isWhitelistEnabled = true; // Set to false to allow all non-blacklisted users
+
+// ----- Admin Moderation Config (platform-level) -----
+
+// Where admin lists live today vs. after migration
+export const ADMIN_LIST_MODE = "local"; // "local" | "nostr"
+
+// Who can edit the admin lists (npub strings)
+export const ADMIN_EDITORS_NPUBS = [
+  // "npub1....", // add yours here
+];
+
+// Optional: one org/admin "authority" key for NIP-26 delegation mode
+export const ADMIN_ORG_NPUB = ""; // leave empty for union-of-admins mode
+
+// Namespace used for NIP-51 parameterized lists (future)
+export const ADMIN_LIST_NAMESPACE = "bitvid:admin";

--- a/js/config.js
+++ b/js/config.js
@@ -8,13 +8,17 @@ export const isWhitelistEnabled = true; // Set to false to allow all non-blackli
 // Where admin lists live today vs. after migration
 export const ADMIN_LIST_MODE = "local"; // "local" | "nostr"
 
-// Who can edit the admin lists (npub strings)
-export const ADMIN_EDITORS_NPUBS = [
-  // "npub1....", // add yours here
-];
+// Super Admin (full control)
+export const ADMIN_SUPER_NPUB =
+  "npub15jnttpymeytm80hatjqcvhhqhzrhx6gxp8pq0wn93rhnu8s9h9dsha32lx";
 
-// Optional: one org/admin "authority" key for NIP-26 delegation mode
-export const ADMIN_ORG_NPUB = ""; // leave empty for union-of-admins mode
+// Optional additional admins (can edit admin lists as well)
+export const ADMIN_EDITORS_NPUBS = [
+  // "npub1....", // add additional moderators here
+];
 
 // Namespace used for NIP-51 parameterized lists (future)
 export const ADMIN_LIST_NAMESPACE = "bitvid:admin";
+
+// Optional: one org/admin "authority" key for NIP-26 delegation mode
+export const ADMIN_ORG_NPUB = ""; // leave empty for union-of-admins mode

--- a/js/lists.js
+++ b/js/lists.js
@@ -18,9 +18,12 @@ const npubs = [
 
 console.log("DEBUG: lists.js loaded, npubs:", npubs);
 
-// Blacklist of npubs that events will not be displayed in the bitvid official client
-export const initialWhitelist = npubs;
-export const initialBlacklist = [""];
+// Admin-level (platform) moderation seeds. NOT user-level blocks.
+export const ADMIN_INITIAL_WHITELIST = npubs;
+export const ADMIN_INITIAL_BLACKLIST = [""];
+export const ADMIN_INITIAL_EVENT_BLACKLIST = [""];
 
-// Block specific events with the nevent
-export const initialEventBlacklist = [""];
+// Back-compat (will be removed after migration):
+export const initialWhitelist = ADMIN_INITIAL_WHITELIST;
+export const initialBlacklist = ADMIN_INITIAL_BLACKLIST;
+export const initialEventBlacklist = ADMIN_INITIAL_EVENT_BLACKLIST;

--- a/js/lists.js
+++ b/js/lists.js
@@ -1,7 +1,7 @@
 // js/lists.js
 
-// Whitelist of npubs that can access the video upload functions
-const npubs = [
+// Admin-level (platform) moderation seeds. NOT user-level blocks.
+const ADMIN_SEED_NPUBS = [
   "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe", // bitvid
   "npub15jnttpymeytm80hatjqcvhhqhzrhx6gxp8pq0wn93rhnu8s9h9dsha32lx", // thePR0M3TH3AN
   "npub1j37gc05qpqzyrmdc5vetsc9h5qtstas7tr25j0n9sdpqxghz6m4q2ej6n8", // Ghost Grid Network
@@ -16,10 +16,7 @@ const npubs = [
   "npub196rl3tls3c4y79pc3ptrrj2430z7p5uwetfhukhtkt69hph0fvwq08l43q", // ~Bordut-Nodlex
 ];
 
-console.log("DEBUG: lists.js loaded, npubs:", npubs);
-
-// Admin-level (platform) moderation seeds. NOT user-level blocks.
-export const ADMIN_INITIAL_WHITELIST = npubs;
+export const ADMIN_INITIAL_WHITELIST = ADMIN_SEED_NPUBS;
 export const ADMIN_INITIAL_BLACKLIST = [""];
 export const ADMIN_INITIAL_EVENT_BLACKLIST = [""];
 


### PR DESCRIPTION
## Summary
- add admin-focused configuration knobs to prepare for future nostr list support
- rename moderation seed exports to ADMIN_* while keeping legacy aliases
- document the admin access controller, migrate storage keys, and centralize channel filtering on it

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d96832e708832b9ee23edc820ffd5c