### PR TITLE
Centralize admin configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ To run **bitvid** locally:
 
 ### Configuration
 
+- **`config/instance-config.js`**:
+  - Central place for instance-specific values like the Super Admin npub and the
+    default whitelist-only mode setting. Update the documented exports here when
+    preparing a new deployment.
 - **`config.js`**:
   - Toggle `isDevMode` for development (`true`) or production (`false`).
 - **`js/constants.js`**:

--- a/config/instance-config.js
+++ b/config/instance-config.js
@@ -1,0 +1,46 @@
+// config/instance-config.js
+// -----------------------------------------------------------------------------
+// BitVid instance configuration
+// -----------------------------------------------------------------------------
+//
+// This file consolidates the values that operators usually customize when they
+// deploy their own BitVid instance. Update the exports below to match your
+// environment, commit the changes, and redeploy. Leaving this file in the repo
+// (instead of hidden in environment variables) makes it easy for future
+// maintainers to understand how your instance is configured.
+//
+// Each setting includes guidance about how BitVid uses the value and what
+// adjustments are safe. When in doubt, mirror the structure shown here so other
+// contributors can follow along.
+
+/**
+ * The primary administrator for this BitVid instance.
+ *
+ * BitVid treats this Nostr public key (npub) as the "Super Admin". This user
+ * cannot be removed from moderator lists, and only they can promote new
+ * moderators or toggle whitelist-only mode. Replace the string below with the
+ * npub of the account you want to act as the ultimate authority for your
+ * deployment.
+ */
+export const ADMIN_SUPER_NPUB =
+  "npub15jnttpymeytm80hatjqcvhhqhzrhx6gxp8pq0wn93rhnu8s9h9dsha32lx";
+
+/**
+ * Storage key used to persist whitelist-only mode in the browser.
+ *
+ * You usually do not need to change this, but the export lives here so that all
+ * whitelist-related knobs are grouped together. If you do change the key, make
+ * sure to migrate any previously stored values in localStorage.
+ */
+export const ADMIN_WHITELIST_MODE_STORAGE_KEY = "bitvid_admin_whitelist_mode";
+
+/**
+ * Whether whitelist-only mode should be enabled the first time an operator
+ * loads the admin dashboard.
+ *
+ * Set this to `true` if you want BitVid to start with whitelist-only access and
+ * require an explicit opt-out. Set to `false` to allow all creators by default.
+ * Operators can still toggle the mode at runtime; this value only controls the
+ * default state when no preference has been stored in localStorage yet.
+ */
+export const DEFAULT_WHITELIST_MODE_ENABLED = false;

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,11 @@
 // js/config.js
 
+import {
+  ADMIN_SUPER_NPUB,
+  ADMIN_WHITELIST_MODE_STORAGE_KEY,
+  DEFAULT_WHITELIST_MODE_ENABLED,
+} from "../config/instance-config.js";
+
 export const isDevMode = true; // Set to false for production
 
 // -----------------------------------------------------------------------------
@@ -7,13 +13,12 @@ export const isDevMode = true; // Set to false for production
 // -----------------------------------------------------------------------------
 
 export const ADMIN_LIST_MODE = "nostr";
-export const ADMIN_SUPER_NPUB =
-  "npub15jnttpymeytm80hatjqcvhhqhzrhx6gxp8pq0wn93rhnu8s9h9dsha32lx";
+export { ADMIN_SUPER_NPUB };
 export const ADMIN_EDITORS_NPUBS = []; // Default moderators (optional)
 export const ADMIN_LIST_NAMESPACE = "bitvid:admin"; // Reserved for Nostr lists
 
-const WHITELIST_MODE_KEY = "bitvid_admin_whitelist_mode";
-const DEFAULT_WHITELIST_ENABLED = false;
+const WHITELIST_MODE_KEY = ADMIN_WHITELIST_MODE_STORAGE_KEY;
+const DEFAULT_WHITELIST_ENABLED = DEFAULT_WHITELIST_MODE_ENABLED;
 
 export function getWhitelistMode() {
   try {
@@ -36,4 +41,4 @@ export function setWhitelistMode(enabled) {
   }
 }
 
-export const ADMIN_WHITELIST_MODE_STORAGE_KEY = WHITELIST_MODE_KEY;
+export { ADMIN_WHITELIST_MODE_STORAGE_KEY };


### PR DESCRIPTION
## Summary
- add `config/instance-config.js` so operators can adjust the super admin npub and whitelist defaults in one place
- update `js/config.js` to consume the centralized values while preserving existing exports
- document the new configuration entry point in the README for easier discovery

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d9eb504500832b9e2616a7b66e2e19