### PR TITLE
Replace moderation relay warning with loading status

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -834,6 +834,32 @@ button:not(.icon-button):focus {
   display: flex;
 }
 
+.status-banner {
+  align-items: center;
+  background-color: rgba(31, 41, 55, 0.9);
+  border-radius: 0.5rem;
+  color: #e5e7eb;
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+
+.status-banner .status-spinner {
+  animation: spin 1s linear infinite;
+  border: 0.125rem solid rgba(229, 231, 235, 0.35);
+  border-radius: 9999px;
+  border-top-color: #f9fafb;
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* Responsive Design */
 @media (max-width: 640px) {
   #videoList {

--- a/index.html
+++ b/index.html
@@ -155,6 +155,17 @@
         class="hidden bg-red-100 text-red-900 p-4 rounded-md mb-4"
       ></div>
 
+      <!-- Status Container -->
+      <div
+        id="statusContainer"
+        class="hidden status-banner"
+        role="status"
+        aria-live="polite"
+      >
+        <span class="status-spinner" aria-hidden="true"></span>
+        <span class="status-message" data-status-message></span>
+      </div>
+
       <!-- Success Container -->
       <div
         id="successContainer"

--- a/js/app.js
+++ b/js/app.js
@@ -663,6 +663,9 @@ class bitvidApp {
     // Notification containers
     this.errorContainer = document.getElementById("errorContainer") || null;
     this.successContainer = document.getElementById("successContainer") || null;
+    this.statusContainer = document.getElementById("statusContainer") || null;
+    this.statusMessage =
+      this.statusContainer?.querySelector("[data-status-message]") || null;
 
     // Auth state
     this.pubkey = null;
@@ -4718,6 +4721,7 @@ class bitvidApp {
 
     let loadError = null;
     this.setAdminLoading(true);
+    this.showStatus("Fetching moderation filters…");
     try {
       await accessControl.ensureReady();
     } catch (error) {
@@ -4741,12 +4745,14 @@ class bitvidApp {
     }
 
     if (loadError) {
+      if (loadError?.code === "nostr-unavailable") {
+        console.info("Moderation lists are still syncing with relays.");
+        return;
+      }
+
       console.error("Failed to load admin lists:", loadError);
-      const message =
-        loadError?.code === "nostr-unavailable"
-          ? "Unable to reach Nostr relays. Moderation lists may be out of date."
-          : "Unable to load moderation lists. Please try again.";
-      this.showError(message);
+      this.showStatus(null);
+      this.showError("Unable to load moderation lists. Please try again.");
       this.clearAdminLists();
       this.setAdminLoading(false);
       return;
@@ -4760,6 +4766,7 @@ class bitvidApp {
       if (adminNav instanceof HTMLElement && adminNav.classList.contains("bg-gray-800")) {
         this.selectProfilePane("account");
       }
+      this.showStatus(null);
       this.setAdminLoading(false);
       return;
     }
@@ -4769,6 +4776,7 @@ class bitvidApp {
       this.adminModeratorsSection.setAttribute("aria-hidden", (!isSuperAdmin).toString());
     }
     this.populateAdminLists();
+    this.showStatus(null);
     this.setAdminLoading(false);
   }
 
@@ -9747,6 +9755,27 @@ class bitvidApp {
       this.errorContainer.textContent = "";
       this.errorContainer.classList.add("hidden");
     }, 5000);
+  }
+
+  showStatus(msg) {
+    if (!(this.statusContainer instanceof HTMLElement)) {
+      return;
+    }
+
+    if (!msg) {
+      if (this.statusMessage instanceof HTMLElement) {
+        this.statusMessage.textContent = "";
+      }
+      this.statusContainer.classList.add("hidden");
+      return;
+    }
+
+    if (this.statusMessage instanceof HTMLElement) {
+      this.statusMessage.textContent = msg;
+    } else {
+      this.statusContainer.textContent = msg;
+    }
+    this.statusContainer.classList.remove("hidden");
   }
 
   showSuccess(msg) {


### PR DESCRIPTION
## Summary
- add a neutral status banner with spinner for moderation list loading state
- keep the loading state instead of showing an error when relays are temporarily unavailable
- style the banner and spinner and wire it into the admin pane refresh logic

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68db5252a444832bb659ec12fb769202