### PR TITLE
Log confirmed video views to Nostr watch history

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -2675,3 +2675,9 @@ class NostrClient {
 }
 
 export const nostrClient = new NostrClient();
+
+export const recordVideoView = (...args) =>
+  nostrClient.recordVideoView(...args);
+
+export const updateWatchHistoryList = (...args) =>
+  nostrClient.updateWatchHistoryList(...args);


### PR DESCRIPTION
## Summary
- derive Nostr pointers when loading event-based videos and skip pointers for direct URLs
- track playback thresholds to publish view events and update the watch-history list with dev-mode warnings on failure
- reset pending playback timers during cleanup to avoid duplicate logging when switching or closing videos

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dbe1b3c434832b8b081417186be9c5