### PR TITLE
Chunk watch history payloads and rebuild fetch pipeline

### DIFF
--- a/config/instance-config.js
+++ b/config/instance-config.js
@@ -83,3 +83,23 @@ export const WATCH_HISTORY_MAX_ITEMS = 1500;
  * bursty loads can disable batching at the cost of additional round trips.
  */
 export const WATCH_HISTORY_BATCH_RESOLVE = true;
+
+/**
+ * Maximum size of the JSON payload for each watch-history chunk, measured
+ * before encryption.
+ *
+ * BitVid splits large histories across multiple events to stay within relay
+ * limits. This cap keeps individual chunks under roughly 60 KB so that
+ * encrypted payloads remain relay-friendly even after base64 expansion.
+ * Lower the number if your relays enforce tighter limits.
+ */
+export const WATCH_HISTORY_PAYLOAD_MAX_BYTES = 60000;
+
+/**
+ * Number of watch-history events to request when syncing from relays.
+ *
+ * Chunked histories can span several events. This fetch limit should exceed
+ * the maximum number of chunks you expect a client to publish in one snapshot
+ * so the UI can stitch the full list back together.
+ */
+export const WATCH_HISTORY_FETCH_EVENT_LIMIT = 12;

--- a/js/config.js
+++ b/js/config.js
@@ -8,6 +8,8 @@ import {
   WATCH_HISTORY_LIST_IDENTIFIER,
   WATCH_HISTORY_MAX_ITEMS,
   WATCH_HISTORY_BATCH_RESOLVE,
+  WATCH_HISTORY_PAYLOAD_MAX_BYTES,
+  WATCH_HISTORY_FETCH_EVENT_LIMIT,
 } from "../config/instance-config.js";
 
 export const isDevMode = true; // Set to false for production
@@ -55,3 +57,5 @@ export { WATCH_HISTORY_KIND };
 export { WATCH_HISTORY_LIST_IDENTIFIER };
 export { WATCH_HISTORY_MAX_ITEMS };
 export { WATCH_HISTORY_BATCH_RESOLVE };
+export { WATCH_HISTORY_PAYLOAD_MAX_BYTES };
+export { WATCH_HISTORY_FETCH_EVENT_LIMIT };


### PR DESCRIPTION
## Summary
- split encrypted watch-history payloads into multiple chunks and publish each with snapshot metadata while respecting the configured size cap
- rewrite watch-history sync to fetch the chunk set, merge the latest snapshot, and honor the new fetch limit overrides
- document the payload limit defaults and add a regression test that exercises chunked publishing and reconstruction

## Testing
- node tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dc1e9d46f4832bbf526e7fd7125996