### PR TITLE
Improve history view loading status messaging

### DIFF
--- a/views/history.html
+++ b/views/history.html
@@ -3,8 +3,19 @@
   <div class="flex items-center justify-between">
     <h2 class="text-2xl font-semibold text-white">Watch History</h2>
   </div>
-  <div id="watchHistoryLoading" class="flex justify-center py-12">
-    <div class="h-10 w-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+  <div
+    id="watchHistoryLoading"
+    class="flex flex-col items-center justify-center py-12 space-y-4"
+  >
+    <div
+      class="h-10 w-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"
+      aria-hidden="true"
+    ></div>
+    <p
+      id="watchHistoryStatus"
+      class="text-gray-300 text-center hidden"
+      aria-live="polite"
+    ></p>
   </div>
   <div id="watchHistoryGrid" class="watch-history-grid hidden"></div>
   <p id="watchHistoryEmpty" class="hidden text-gray-400 text-center py-12">


### PR DESCRIPTION
## Summary
- add an aria-live status message next to the watch history spinner so it can verbalize loading progress
- teach the history renderer to manage the new status element during loading, empty, and success states

## Testing
- node --loader ./tmp-loader.mjs --input-type=module <<'EOF' … EOF (manual sanity check via stubbed DOM harness)


------
https://chatgpt.com/codex/tasks/task_b_68dc29d08c58832ba8b4c7fe34f07633