### PR TITLE
Add status messaging to profile watch history loading state

### DIFF
--- a/components/profile-modal.html
+++ b/components/profile-modal.html
@@ -291,8 +291,17 @@
                 Your recently watched videos appear here so you can jump back into favorites.
               </p>
               <div class="space-y-4">
-                <div id="profileHistoryLoading" class="flex justify-center py-6">
+                <div
+                  id="profileHistoryLoading"
+                  class="flex items-center justify-center gap-3 py-6"
+                >
                   <div class="h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+                  <p
+                    id="profileHistoryStatus"
+                    class="text-sm text-gray-300 hidden"
+                    aria-live="polite"
+                    role="status"
+                  ></p>
                 </div>
                 <div
                   id="profileHistoryEmpty"

--- a/js/app.js
+++ b/js/app.js
@@ -3951,6 +3951,7 @@ class bitvidApp {
           viewSelector: "#profilePaneHistory",
           gridSelector: "#profileHistoryGrid",
           loadingSelector: "#profileHistoryLoading",
+          statusSelector: "#profileHistoryStatus",
           emptySelector: "#profileHistoryEmpty",
           sentinelSelector: "#profileHistorySentinel",
           scrollContainerSelector: "#profileHistoryScroll",


### PR DESCRIPTION
## Summary
- add an aria-live status element alongside the profile modal watch history spinner
- pass the new status selector to the watch history renderer so loading messages appear during fetches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dc38b1b7ac832baf484b5fddca1cb7