### PR TITLE
Add shared timeout wrapper for NIP-07 login flows

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -62,10 +62,19 @@ function withNip07Timeout(operation) {
     }, NIP07_LOGIN_TIMEOUT_MS);
   });
 
-  return Promise.race([
-    Promise.resolve().then(operation),
-    timeoutPromise,
-  ]).finally(() => {
+  let operationResult;
+  try {
+    operationResult = operation();
+  } catch (err) {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    throw err;
+  }
+
+  const operationPromise = Promise.resolve(operationResult);
+
+  return Promise.race([operationPromise, timeoutPromise]).finally(() => {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }


### PR DESCRIPTION
## Summary
- add a reusable helper that enforces the existing NIP-07 login timeout and error message
- wrap extension.enable, selectAccounts, and getPublicKey with the shared timeout logic so prompts resolve or surface an error

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dc39f0c238832ba151cc471eb54436