### PR TITLE
Add Nostr COUNT helper and surface discussion counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ latest styles.
 - **Magnet helpers**:
   - Use `safeDecodeMagnet()` and `normalizeAndAugmentMagnet()` from `js/magnetUtils.js` to preserve hashes and add `ws=` / `xs=` hints safely.
 
+### Relay compatibility
+
+Bitvid now requests per-video discussion counts using the NIP-45 `COUNT` frame. The bundled client opens each relay via
+`this.pool.ensureRelay(url)` and streams a raw `COUNT` message, so your relay stack must understand that verb (nostr-tools ≥ 1.8
+or any relay advertising NIP-45 support). Relays that do not implement `COUNT` are skipped gracefully—the UI keeps the count
+placeholder at “—” and development builds log a warning—so mixed deployments remain usable while you phase in compatible relays.
+
 ### Adding Features
 
 1. **Fork the repository** and create a new branch for your feature.


### PR DESCRIPTION
## Summary
- add a generic request-timeout helper and COUNT request utilities to the Nostr client
- fetch per-video discussion totals across relays with COUNT frames and cache the results in the app UI
- surface the aggregated note counts in each video card and document the relay compatibility requirement for COUNT support

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dc8786b84c832bb0fdf378cd7c27cd