### PR TITLE
Add live view counters to video list and modal

### DIFF
--- a/components/video-modal.html
+++ b/components/video-modal.html
@@ -133,7 +133,10 @@
         <div
           class="flex items-center justify-between text-sm text-gray-400 mb-4"
         >
-          <span id="videoTimestamp">just now</span>
+          <div class="flex items-center gap-2 modal-meta">
+            <span id="videoTimestamp">just now</span>
+            <span id="videoViewCount" class="modal-view-count">– views</span>
+          </div>
           <div id="modalStatus" class="text-gray-300">
             Initializing... Just give it a sec.
           </div>

--- a/css/style.css
+++ b/css/style.css
@@ -885,6 +885,27 @@ header img {
   box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.35);
 }
 
+.modal-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.modal-view-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: #9ca3af;
+  white-space: nowrap;
+}
+
+.view-count-text {
+  white-space: nowrap;
+  color: #6b7280;
+}
+
 html.modal-open {
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- integrate the shared view counter module into the app and initialize it with the active Nostr client
- display live-updating view totals on video cards and in the playback modal while cleaning up subscriptions as lists rerender or the modal closes
- optimistically update local totals after recording a view and expose matching markup/styles for the modal counter

## Testing
- Manual smoke test in browser (static assets served via python -m http.server)


------
https://chatgpt.com/codex/tasks/task_b_68dc914b9ef8832ba2f5f80674a3d981