### PR TITLE
Fix per-identity view logging

### DIFF
--- a/docs/qa.md
+++ b/docs/qa.md
@@ -20,5 +20,8 @@ Run this checklist before publishing releases or merging changes that touch uplo
 6. **Saved Profile Metadata Refresh**
    - In the browser devtools console/storage panel, delete `bitvid:profileCache:v1` but keep `bitvid:savedProfiles:v1` populated with Nostr pubkeys that lack stored names/avatars.
    - Reload the page and open the profile switcher; confirm avatars and display names populate automatically without manual refresh.
+7. **View Logging Per Identity**
+   - Play the same video until a view event is logged, then log out (or switch to a different pubkey) and repeat the playback.
+   - Confirm two distinct view events appear (e.g., via relay logs or UI counters) and the aggregated view count increments twice.
 
 Document findings (pass/fail notes plus relevant screenshots or logs) so they can be attached to release or PR notes.


### PR DESCRIPTION
## Summary
- reset the playback view logging state whenever the active pubkey changes or a user logs out
- scope the logged-view cooldown keys by both the pointer and the actor that generated the view event
- document manual QA that verifies cross-account playback increments the view counter twice

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dc9a69f88c832b958b2701939b7279