### PR TITLE
Fix COUNT aggregation to avoid duplicate view totals

### DIFF
--- a/js/viewCounter.js
+++ b/js/viewCounter.js
@@ -485,10 +485,18 @@ async function hydratePointer(key, listeners) {
       mutated = applyEventToState(key, event) || mutated;
     }
   }
-  if (countResult && Number.isFinite(countResult.total)) {
+  const bestCount = Number.isFinite(countResult?.best?.count)
+    ? Number(countResult.best.count)
+    : Number.isFinite(countResult?.total)
+    ? Number(countResult.total)
+    : null;
+
+  if (bestCount !== null) {
     const state = ensurePointerState(key);
-    if (countResult.total > state.total) {
-      state.total = Number(countResult.total);
+    const shouldUpdate =
+      !countResult?.fallback || bestCount >= state.total || state.total === 0;
+    if (shouldUpdate && state.total !== bestCount) {
+      state.total = bestCount;
       state.lastSyncedAt = Date.now();
       mutated = true;
     }


### PR DESCRIPTION
## Summary
- treat per-relay COUNT responses as competing estimates and track the best relay result
- surface the best COUNT estimate to the view counter and update totals even when the estimate falls below cached state
- expand the view counter harness and add a regression test covering duplicate relay COUNT responses

## Testing
- node tests/view-counter.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dd27a1c314832b8ed9a93f303e0dc7