### PR TITLE
Align sidebar loading states and history heading

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,7 @@ import { URL_FIRST_ENABLED } from "./constants.js";
 import { trackVideoView } from "./analytics.js";
 import { attachHealthBadges } from "./gridHealth.js";
 import { attachUrlHealthBadges } from "./urlHealthObserver.js";
+import { buildFetchingMessage } from "./loadingTemplates.js";
 import { ADMIN_INITIAL_EVENT_BLACKLIST } from "./lists.js";
 import { userBlocks } from "./userBlocks.js";
 import {
@@ -7534,10 +7535,9 @@ class bitvidApp {
     if (!this.videoSubscription) {
       if (this.videoList) {
         this.lastRenderedVideoSignature = null;
-        this.videoList.innerHTML = `
-        <p class="text-center text-gray-500">
-          Loading videos as they arrive...
-        </p>`;
+        this.videoList.innerHTML = buildFetchingMessage(
+          "Fetching recent videos..."
+        );
       }
 
       // Create a new subscription

--- a/js/loadingTemplates.js
+++ b/js/loadingTemplates.js
@@ -1,0 +1,32 @@
+// js/loadingTemplates.js
+
+const HTML_ESCAPE_LOOKUP = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+const HTML_ESCAPE_PATTERN = /[&<>"']/g;
+
+function escapeHtml(value) {
+  if (typeof value !== "string" || !value) {
+    return "";
+  }
+
+  return value.replace(HTML_ESCAPE_PATTERN, (char) => HTML_ESCAPE_LOOKUP[char] || char);
+}
+
+export function buildFetchingMessage(message) {
+  const fallback = "Fetching…";
+  const trimmed = typeof message === "string" ? message.trim() : "";
+  const safeMessage = trimmed || fallback;
+
+  return `
+    <div class="flex flex-col items-center justify-center py-12 space-y-4 text-gray-500">
+      <span class="status-spinner status-spinner--inline" aria-hidden="true"></span>
+      <p class="text-center">${escapeHtml(safeMessage)}</p>
+    </div>
+  `;
+}

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -5,6 +5,7 @@ import {
 } from "./nostr.js";
 import { attachHealthBadges } from "./gridHealth.js";
 import { attachUrlHealthBadges } from "./urlHealthObserver.js";
+import { buildFetchingMessage } from "./loadingTemplates.js";
 
 function getAbsoluteShareUrl(nevent) {
   if (!nevent) {
@@ -210,13 +211,16 @@ class SubscriptionsManager {
       if (c) c.innerHTML = "<p class='text-gray-500'>Please log in first.</p>";
       return;
     }
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    container.innerHTML = buildFetchingMessage("Fetching subscriptions...");
+
     if (!this.loaded) {
       await this.loadSubscriptions(userPubkey);
     }
 
     const channelHexes = Array.from(this.subscribedPubkeys);
-    const container = document.getElementById(containerId);
-    if (!container) return;
 
     if (!channelHexes.length) {
       container.innerHTML =

--- a/views/history.html
+++ b/views/history.html
@@ -1,8 +1,6 @@
 <!-- views/history.html -->
 <section id="watchHistoryView" class="space-y-6">
-  <div class="flex items-center justify-between">
-    <h2 class="text-2xl font-semibold text-white">Watch History</h2>
-  </div>
+  <h2 class="text-xl mb-4 text-gray-700">Watch History</h2>
   <div
     id="watchHistoryLoading"
     class="flex flex-col items-center justify-center py-12 space-y-4"
@@ -13,9 +11,11 @@
     ></div>
     <p
       id="watchHistoryStatus"
-      class="text-gray-300 text-center hidden"
+      class="text-gray-500 text-center hidden"
       aria-live="polite"
-    ></p>
+    >
+      Fetching watch history from relays...
+    </p>
   </div>
   <div id="watchHistoryGrid" class="watch-history-grid hidden"></div>
   <p id="watchHistoryEmpty" class="hidden text-gray-400 text-center py-12">


### PR DESCRIPTION
## Summary
- match the watch history sidebar heading styling with the explore and recent tabs
- add consistent fetching spinners for recent videos and subscriptions using a shared helper
- seed the watch history status with a fetching message for better fallback text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd5dc45a6c832b98a0304aa567b4d8