### PR TITLE
Fix stuck recent videos spinner and align watch history loader

### DIFF
--- a/components/profile-modal.html
+++ b/components/profile-modal.html
@@ -291,17 +291,24 @@
                 Your recently watched videos appear here so you can jump back into favorites.
               </p>
               <div class="space-y-4">
-                <div
-                  id="profileHistoryLoading"
-                  class="flex items-center justify-center gap-3 py-6"
-                >
-                  <div class="h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-                  <p
-                    id="profileHistoryStatus"
-                    class="text-sm text-gray-300 hidden"
-                    aria-live="polite"
-                    role="status"
-                  ></p>
+                <div id="profileHistoryLoading" class="py-6">
+                  <div id="profileHistoryStatus">
+                    <div
+                      class="sidebar-loading-wrapper"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <div class="sidebar-loading-indicator">
+                        <span
+                          class="status-spinner status-spinner--inline"
+                          aria-hidden="true"
+                        ></span>
+                        <span class="sidebar-loading-text"
+                          >Fetching watch history from relays…</span
+                        >
+                      </div>
+                    </div>
+                  </div>
                 </div>
                 <div
                   id="profileHistoryEmpty"

--- a/js/app.js
+++ b/js/app.js
@@ -7720,9 +7720,11 @@ class bitvidApp {
     }
 
     if (this.videoList) {
-      if (this._lastRenderedVideoListElement !== this.videoList) {
-        this.lastRenderedVideoSignature = null;
-      }
+      // Always reset the cached signature before showing the loading state so the
+      // next render isn't skipped when the incoming payload matches the last
+      // successful render. Without this, the spinner could remain visible for
+      // returning users who already have the latest list cached.
+      this.lastRenderedVideoSignature = null;
       this.videoList.innerHTML = getSidebarLoadingMarkup(
         "Fetching recent videos…"
       );


### PR DESCRIPTION
## Summary
- reset the cached recent videos render signature when displaying the loading spinner so the list re-renders after cached fetches
- swap the profile watch history loader to the shared sidebar loading markup for a consistent spinner between logged-in and logged-out states

## Testing
- Manual QA: `python3 -m http.server 4173`

------
https://chatgpt.com/codex/tasks/task_b_68dd703eb1fc832bb90f8f7da720a959