### PR TITLE
Add client guard for view event publishing

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,7 @@
 const DEFAULT_FLAGS = Object.freeze({
   URL_FIRST_ENABLED: true,   // try URL before magnet in the player
   ACCEPT_LEGACY_V1: true,    // accept v1 magnet-only notes
+  VIEW_FILTER_INCLUDE_LEGACY_VIDEO: false,
   WSS_TRACKERS: Object.freeze([
     "wss://tracker.openwebtorrent.com",
     "wss://tracker.btorrent.xyz",
@@ -17,6 +18,8 @@ const runtimeFlags = (() => {
   const initial = {
     URL_FIRST_ENABLED: DEFAULT_FLAGS.URL_FIRST_ENABLED,
     ACCEPT_LEGACY_V1: DEFAULT_FLAGS.ACCEPT_LEGACY_V1,
+    VIEW_FILTER_INCLUDE_LEGACY_VIDEO:
+      DEFAULT_FLAGS.VIEW_FILTER_INCLUDE_LEGACY_VIDEO,
     WSS_TRACKERS: [...DEFAULT_FLAGS.WSS_TRACKERS],
   };
   if (globalScope) {
@@ -92,6 +95,11 @@ export let ACCEPT_LEGACY_V1 = coerceBoolean(
   DEFAULT_FLAGS.ACCEPT_LEGACY_V1
 );
 
+export let VIEW_FILTER_INCLUDE_LEGACY_VIDEO = coerceBoolean(
+  runtimeFlags.VIEW_FILTER_INCLUDE_LEGACY_VIDEO,
+  DEFAULT_FLAGS.VIEW_FILTER_INCLUDE_LEGACY_VIDEO
+);
+
 export let WSS_TRACKERS = freezeTrackers(
   sanitizeTrackerList(runtimeFlags.WSS_TRACKERS)
 );
@@ -118,6 +126,20 @@ Object.defineProperty(runtimeFlags, "ACCEPT_LEGACY_V1", {
   },
 });
 
+Object.defineProperty(runtimeFlags, "VIEW_FILTER_INCLUDE_LEGACY_VIDEO", {
+  configurable: true,
+  enumerable: true,
+  get() {
+    return VIEW_FILTER_INCLUDE_LEGACY_VIDEO;
+  },
+  set(next) {
+    VIEW_FILTER_INCLUDE_LEGACY_VIDEO = coerceBoolean(
+      next,
+      DEFAULT_FLAGS.VIEW_FILTER_INCLUDE_LEGACY_VIDEO
+    );
+  },
+});
+
 Object.defineProperty(runtimeFlags, "WSS_TRACKERS", {
   configurable: true,
   enumerable: true,
@@ -132,6 +154,7 @@ Object.defineProperty(runtimeFlags, "WSS_TRACKERS", {
 // Ensure the runtime object reflects the sanitized defaults immediately.
 runtimeFlags.URL_FIRST_ENABLED = URL_FIRST_ENABLED;
 runtimeFlags.ACCEPT_LEGACY_V1 = ACCEPT_LEGACY_V1;
+runtimeFlags.VIEW_FILTER_INCLUDE_LEGACY_VIDEO = VIEW_FILTER_INCLUDE_LEGACY_VIDEO;
 runtimeFlags.WSS_TRACKERS = WSS_TRACKERS;
 
 export function setUrlFirstEnabled(next) {
@@ -144,6 +167,11 @@ export function setAcceptLegacyV1(next) {
   return ACCEPT_LEGACY_V1;
 }
 
+export function setViewFilterIncludeLegacyVideo(next) {
+  runtimeFlags.VIEW_FILTER_INCLUDE_LEGACY_VIDEO = next;
+  return VIEW_FILTER_INCLUDE_LEGACY_VIDEO;
+}
+
 export function setWssTrackers(next) {
   runtimeFlags.WSS_TRACKERS = next;
   return WSS_TRACKERS;
@@ -152,6 +180,9 @@ export function setWssTrackers(next) {
 export function resetRuntimeFlags() {
   setUrlFirstEnabled(DEFAULT_FLAGS.URL_FIRST_ENABLED);
   setAcceptLegacyV1(DEFAULT_FLAGS.ACCEPT_LEGACY_V1);
+  setViewFilterIncludeLegacyVideo(
+    DEFAULT_FLAGS.VIEW_FILTER_INCLUDE_LEGACY_VIDEO
+  );
   setWssTrackers(DEFAULT_FLAGS.WSS_TRACKERS);
 }
 


### PR DESCRIPTION
## Summary
- gate the legacy `#video` filter behind a runtime flag so view queries rely on standard pointer tags
- add a local-storage backed guard in `publishViewEvent` to skip duplicate publishes and remember successful buckets
- feed signed view events into the local counter and reuse pointer tags when parsing received events

## Testing
- node tests/view-counter.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dd8442934c832b8ebc7e705b06af57