### PR TITLE
Ensure playback uses fallback pointer for view logging

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10615,13 +10615,26 @@ class bitvidApp {
       typeof (video.id || eventId) === "string"
         ? (video.id || eventId).trim()
         : "";
-    const fallbackPointer =
-      !primaryPointer && fallbackId
-        ? ["e", fallbackId]
-        : null;
+    const fallbackPointer = fallbackId ? ["e", fallbackId] : null;
 
-    const resolvedPointer = primaryPointer || fallbackPointer;
-    const resolvedPointerKey = pointerArrayToKey(resolvedPointer);
+    let resolvedPointer = null;
+    let resolvedPointerKey = "";
+    const pointerCandidates = [];
+    if (primaryPointer) {
+      pointerCandidates.push(primaryPointer);
+    }
+    if (fallbackPointer) {
+      pointerCandidates.push(fallbackPointer);
+    }
+
+    for (const candidate of pointerCandidates) {
+      const key = pointerArrayToKey(candidate);
+      if (key) {
+        resolvedPointer = candidate;
+        resolvedPointerKey = key;
+        break;
+      }
+    }
 
     this.currentVideoPointer = resolvedPointer && resolvedPointerKey
       ? resolvedPointer


### PR DESCRIPTION
## Summary
- fall back to the event-based pointer when a replaceable pointer cannot produce a key
- keep modal view counts and watch history logging working for videos that are missing a usable d-tag pointer

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dd898298ac832bbd9452a8158f12e9