### PR TITLE
Add default JSON payload to view events

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -2785,8 +2785,50 @@ class NostrClient {
         ? ["e", pointer.value, pointer.relay]
         : ["e", pointer.value];
 
-    const content =
-      typeof options.content === "string" ? options.content : "";
+    let content = "";
+    if (typeof options.content === "string") {
+      content = options.content;
+    } else if (
+      options.content &&
+      typeof options.content === "object" &&
+      !Array.isArray(options.content)
+    ) {
+      try {
+        content = JSON.stringify(options.content);
+      } catch (error) {
+        if (isDevMode) {
+          console.warn(
+            "[nostr] Failed to serialize custom view event content:",
+            error
+          );
+        }
+        content = "";
+      }
+    }
+
+    if (!content) {
+      const payload = {
+        target: {
+          type: pointer.type,
+          value: pointer.value,
+        },
+        created_at: createdAt,
+      };
+      if (pointer.relay) {
+        payload.target.relay = pointer.relay;
+      }
+      try {
+        content = JSON.stringify(payload);
+      } catch (error) {
+        if (isDevMode) {
+          console.warn(
+            "[nostr] Failed to serialize default view event content:",
+            error
+          );
+        }
+        content = "";
+      }
+    }
 
     const event = buildViewEvent({
       pubkey: actorPubkey,


### PR DESCRIPTION
## Summary
- generate a default JSON payload for view events when no custom content is supplied, capturing the target pointer and timestamp
- normalize view event content to a UTF-8 safe string before signing
- add recordVideoView coverage to the view counter tests to ensure JSON payloads ingest without errors

## Testing
- node tests/view-counter.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dd9fc45a94832b8478b3f1baed6ab3