### PR TITLE
Update view counter test expectations

### DIFF
--- a/tests/view-counter.test.mjs
+++ b/tests/view-counter.test.mjs
@@ -577,7 +577,11 @@ async function testRecordVideoViewEmitsJsonPayload() {
   };
   nostrClient.pubkey = "";
 
-  nostrClient.updateWatchHistoryList = async () => ({ ok: true });
+  nostrClient.updateWatchHistoryList = async () => {
+    throw new Error(
+      "recordVideoView should not invoke updateWatchHistoryList during view publishes"
+    );
+  };
 
   try {
     const result = await nostrClient.recordVideoView(pointer, {
@@ -614,7 +618,7 @@ async function testRecordVideoViewEmitsJsonPayload() {
     );
 
     assert.equal(
-      result.view.event.content,
+      result.event.content,
       emittedEvent.content,
       "serialized payload should persist on the emitted event"
     );


### PR DESCRIPTION
## Summary
- expect `recordVideoView` tests to assert against the returned publish result object
- guard the watch history stub so the test fails if `recordVideoView` calls it

## Testing
- node tests/view-counter.test.mjs
- node tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dda8ef85bc832b83b5866b6b1a10a2