### PR TITLE
Restore canonical watch history identifier and prefetch triggers

### DIFF
--- a/config/instance-config.js
+++ b/config/instance-config.js
@@ -63,14 +63,14 @@ export const WATCH_HISTORY_KIND = 30078;
  * BitVid deployments that share relays, but keep it stable once clients begin
  * syncing history.
  */
-export const WATCH_HISTORY_LIST_IDENTIFIER = "watch-history:v2:index";
+export const WATCH_HISTORY_LIST_IDENTIFIER = "watch-history";
 
 /**
  * Legacy identifiers that BitVid clients should continue honoring when
  * fetching historical watch-history snapshots.
  */
 export const WATCH_HISTORY_LEGACY_LIST_IDENTIFIERS = Object.freeze([
-  "watch-history",
+  "watch-history:v2:index",
 ]);
 
 /**

--- a/docs/nostr-event-schemas.md
+++ b/docs/nostr-event-schemas.md
@@ -64,10 +64,12 @@ builders inherit the same debugging knobs.
 ### Watch history identifiers
 
 Watch-history snapshots now publish a dedicated index event with
-`#d ${WATCH_HISTORY_LIST_IDENTIFIER}` (defaults to `watch-history:v2:index`). The
+`#d ${WATCH_HISTORY_LIST_IDENTIFIER}` (defaults to `watch-history`). The
 index advertises the active snapshot id, total chunk count, and a pointer to
 each chunk via `a` tags so clients can fetch the encrypted payloads without
-guessing identifiers.
+guessing identifiers. Deployments that previously used
+`watch-history:v2:index` continue to resolve thanks to the legacy identifier
+list.
 
 Every chunk event uses a unique `d` tag such as
 `watch-history:v2/<snapshot>/<chunkIndex>`. Legacy snapshots created before the

--- a/js/app.js
+++ b/js/app.js
@@ -4283,6 +4283,29 @@ class bitvidApp {
         }
         button.dataset.navBound = "true";
         button.addEventListener("click", () => {
+          if (name === "history") {
+            let actorCandidate;
+            if (typeof this.pubkey === "string" && this.pubkey.trim()) {
+              actorCandidate = this.pubkey.trim();
+            } else if (
+              typeof window?.app?.pubkey === "string" &&
+              window.app.pubkey.trim()
+            ) {
+              actorCandidate = window.app.pubkey.trim();
+            }
+
+            void nostrClient
+              .fetchWatchHistory(actorCandidate, { forceRefresh: true })
+              .catch((error) => {
+                if (isDevMode) {
+                  console.warn(
+                    "[profileModal] Failed to prefetch watch history on navigation:",
+                    error
+                  );
+                }
+              });
+          }
+
           this.selectProfilePane(name);
         });
       });

--- a/js/nostr.js
+++ b/js/nostr.js
@@ -58,7 +58,28 @@ const WATCH_HISTORY_INDEX_IDENTIFIER_LOWER =
     ? WATCH_HISTORY_LIST_IDENTIFIER.trim().toLowerCase()
     : "";
 
-const WATCH_HISTORY_CHUNK_V2_PREFIX = "watch-history:v2";
+const WATCH_HISTORY_CHUNK_V2_PREFIX = (() => {
+  const rawIdentifier =
+    typeof WATCH_HISTORY_LIST_IDENTIFIER === "string"
+      ? WATCH_HISTORY_LIST_IDENTIFIER.trim()
+      : "";
+
+  if (rawIdentifier) {
+    const trimmed = rawIdentifier.replace(/\/+$/, "");
+    if (/[:/]index$/i.test(trimmed)) {
+      const base = trimmed.replace(/[:/]index$/i, "").replace(/\/+$/, "");
+      return base || "watch-history:v2";
+    }
+
+    if (/:v\d+$/i.test(trimmed)) {
+      return trimmed;
+    }
+
+    return `${trimmed}:v2`;
+  }
+
+  return "watch-history:v2";
+})();
 
 const LEGACY_WATCH_HISTORY_CHUNK_IDENTIFIER_PREFIX = (() => {
   const rawIdentifier =

--- a/tests/watch-history.test.mjs
+++ b/tests/watch-history.test.mjs
@@ -109,9 +109,30 @@ function createDecryptClient(actorPubkey) {
 }
 
 const ACTOR = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-const WATCH_HISTORY_CHUNK_PREFIX = WATCH_HISTORY_LIST_IDENTIFIER.replace(
-  /[:/]index$/i,
-  ""
+function deriveChunkPrefix(identifier) {
+  if (typeof identifier !== "string") {
+    return "watch-history:v2";
+  }
+
+  const trimmed = identifier.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return "watch-history:v2";
+  }
+
+  if (/[:/]index$/i.test(trimmed)) {
+    const base = trimmed.replace(/[:/]index$/i, "").replace(/\/+$/, "");
+    return base || "watch-history:v2";
+  }
+
+  if (/:v\d+$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `${trimmed}:v2`;
+}
+
+const WATCH_HISTORY_CHUNK_PREFIX = deriveChunkPrefix(
+  WATCH_HISTORY_LIST_IDENTIFIER
 );
 
 const indexSchema = getNostrEventSchema(NOTE_TYPES.WATCH_HISTORY_INDEX);


### PR DESCRIPTION
## Summary
- set the watch-history list identifier back to `watch-history` while keeping the v2 index identifier in the legacy list
- derive watch-history chunk identifiers from the configured list id and refresh documentation plus unit tests
- prefetch the latest watch history when the profile modal tab or sidebar history link is clicked

## Testing
- node tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68ddad50ef8c832b8c96841ba4d8d7ba