### PR TITLE
Refresh default WSS trackers

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -4,8 +4,9 @@ const DEFAULT_FLAGS = Object.freeze({
   VIEW_FILTER_INCLUDE_LEGACY_VIDEO: false,
   WSS_TRACKERS: Object.freeze([
     "wss://tracker.openwebtorrent.com",
-    "wss://tracker.btorrent.xyz",
+    "wss://tracker.fastcast.nz",
     "wss://tracker.webtorrent.dev",
+    "wss://tracker.sloppyta.co:443/announce",
   ]),
 });
 

--- a/js/webtorrent.js
+++ b/js/webtorrent.js
@@ -1,11 +1,9 @@
 //js/webtorrent.js
 
 import WebTorrent from "./webtorrent.min.js";
+import { WSS_TRACKERS } from "./constants.js";
 
-const DEFAULT_PROBE_TRACKERS = Object.freeze([
-  "wss://tracker.btorrent.xyz",
-  "wss://tracker.openwebtorrent.com",
-]);
+const DEFAULT_PROBE_TRACKERS = Object.freeze([...WSS_TRACKERS]);
 
 function decodeComponentSafe(value) {
   if (typeof value !== "string") {


### PR DESCRIPTION
## Summary
- replace the dead btorrent WebSocket tracker entry with reliable WSS trackers in the runtime defaults
- source TorrentClient probe defaults from the shared tracker list so health checks stay aligned

## Testing
- node tests/magnet-utils.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68ddc0169000832baf57f2786f283c72