### PR TITLE
Increase watch history fetch capacity for large snapshots

### DIFF
--- a/config/instance-config.js
+++ b/config/instance-config.js
@@ -110,7 +110,7 @@ export const WATCH_HISTORY_PAYLOAD_MAX_BYTES = 60000;
  * the maximum number of chunks you expect a client to publish in one snapshot
  * so the UI can stitch the full list back together.
  */
-export const WATCH_HISTORY_FETCH_EVENT_LIMIT = 12;
+export const WATCH_HISTORY_FETCH_EVENT_LIMIT = 64;
 
 /**
  * How long clients should cache watch-history snapshots in localStorage.

--- a/js/nostr.js
+++ b/js/nostr.js
@@ -3823,11 +3823,37 @@ class NostrClient {
       this.watchHistoryCache.delete(actor);
     }
 
+    let newestSnapshotChunkTarget = 0;
+    let newestSnapshotIdentifierTarget = 0;
+    if (latestIndexSnapshotMeta?.snapshotId) {
+      const latestSnapshotMeta = indexSnapshots.get(
+        latestIndexSnapshotMeta.snapshotId
+      );
+      if (latestSnapshotMeta) {
+        const totalChunksForLatest = Number.isFinite(
+          latestSnapshotMeta.totalChunks
+        )
+          ? Math.max(0, Math.floor(latestSnapshotMeta.totalChunks))
+          : 0;
+        if (totalChunksForLatest > 0) {
+          newestSnapshotChunkTarget = totalChunksForLatest + 1;
+        }
+        if (latestSnapshotMeta.chunkIdentifiers instanceof Set) {
+          const identifierCount = latestSnapshotMeta.chunkIdentifiers.size;
+          if (identifierCount > 0) {
+            newestSnapshotIdentifierTarget = identifierCount + 1;
+          }
+        }
+      }
+    }
+
     const chunkFilters = [];
     const chunkFetchLimit = Math.max(
       fetchLimit,
       chunkIdentifiers.size ? chunkIdentifiers.size + 1 : 0,
-      snapshotIds.size ? snapshotIds.size * 2 : 0
+      snapshotIds.size ? snapshotIds.size * 2 : 0,
+      newestSnapshotChunkTarget,
+      newestSnapshotIdentifierTarget
     );
 
     if (chunkIdentifiers.size) {


### PR DESCRIPTION
## Summary
- raise the default WATCH_HISTORY_FETCH_EVENT_LIMIT so default fetches comfortably exceed expected chunk counts
- derive chunkFetchLimit from the latest snapshot metadata so totalChunks plus the index event are always fetched
- refresh watch history tests to use the higher limit and cover snapshots that exceed the legacy cap

## Testing
- node tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68ddcd369128832bbd5b28048618b7d4