### PR TITLE
Guard watch history publish when relays omit seen listener

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -1171,8 +1171,23 @@ function publishEventToRelay(pool, url, event) {
         let handlerRegistered = false;
         handlerRegistered =
           registerHandler("ok", handleSuccess) || handlerRegistered;
-        handlerRegistered =
-          registerHandler("seen", handleSuccess) || handlerRegistered;
+
+        const supportsSeenEvent = (() => {
+          if (!pub || typeof pub !== "object") {
+            return false;
+          }
+          const candidateArrays = [
+            pub.seen,
+            pub._seen,
+            pub.listeners?.seen,
+          ];
+          return candidateArrays.some((value) => Array.isArray(value));
+        })();
+
+        if (supportsSeenEvent) {
+          handlerRegistered =
+            registerHandler("seen", handleSuccess) || handlerRegistered;
+        }
         handlerRegistered =
           registerHandler("failed", handleFailure) || handlerRegistered;
 

--- a/tests/watch-history.test.mjs
+++ b/tests/watch-history.test.mjs
@@ -604,11 +604,14 @@ const {
   publishedEvents: noSeenPublishedEvents,
 } = createPublishingClient(NO_SEEN_ACTOR);
 
+let noSeenHandlerRequested = false;
+
 noSeenClient.pool.publish = (_urls, event) => {
   noSeenPublishedEvents.push(event);
   return {
     on(eventName, handler) {
       if (eventName === "seen") {
+        noSeenHandlerRequested = true;
         throw new TypeError("seen unsupported");
       }
       if (eventName === "ok") {
@@ -633,6 +636,11 @@ assert.equal(
 assert(
   noSeenResult.events.length > 0,
   "publish should still return the emitted events when seen is unsupported"
+);
+assert.equal(
+  noSeenHandlerRequested,
+  false,
+  "publish should not attempt to register a seen handler when relay omits support"
 );
 
 delete globalThis.window.nostr;


### PR DESCRIPTION
## Summary
- guard nostr publish against registering a `seen` handler when the relay implementation lacks support
- extend the no-seen regression test to confirm we never register the unsupported listener

## Testing
- node tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68ddd2198a90832ba0f4b86cc10d2152