### PR TITLE
Handle legacy watch history payloads without JSON parse errors

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -3720,23 +3720,38 @@ class NostrClient {
       const isIndexEvent = isIndexIdentifier(identifier);
 
       if (isIndexEvent && typeof event.content === "string") {
-        try {
-          const parsed = JSON.parse(event.content);
-          if (!snapshotId && typeof parsed?.snapshot === "string" && parsed.snapshot) {
-            snapshotId = parsed.snapshot;
-          }
-          if (
-            totalChunks === null &&
-            Number.isFinite(Number.parseInt(parsed?.totalChunks, 10))
-          ) {
-            totalChunks = Math.max(0, Math.floor(Number.parseInt(parsed.totalChunks, 10)));
-          }
-        } catch (error) {
-          if (isDevMode) {
-            console.warn(
-              "[nostr] Failed to parse watch history index payload:",
-              error
-            );
+        const trimmedContent = event.content.trim();
+        if (trimmedContent) {
+          const firstChar = trimmedContent[0];
+          if (firstChar === "{" || firstChar === "[") {
+            try {
+              const parsed = JSON.parse(trimmedContent);
+              if (
+                !snapshotId &&
+                typeof parsed?.snapshot === "string" &&
+                parsed.snapshot
+              ) {
+                snapshotId = parsed.snapshot;
+              }
+              if (
+                totalChunks === null &&
+                Number.isFinite(Number.parseInt(parsed?.totalChunks, 10))
+              ) {
+                totalChunks = Math.max(
+                  0,
+                  Math.floor(Number.parseInt(parsed.totalChunks, 10))
+                );
+              }
+            } catch (error) {
+              if (isDevMode) {
+                console.warn(
+                  "[nostr] Failed to parse watch history index payload:",
+                  error
+                );
+              }
+            }
+          } else if (!snapshotId) {
+            snapshotId = trimmedContent;
           }
         }
       }


### PR DESCRIPTION
## Summary
- trim watch history index event content before parsing
- skip JSON parsing for legacy base64/plain payloads and use them as snapshot IDs when needed

## Testing
- node --test tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68dde06f4108832b980b8bf4a0a5d3f3