### PR TITLE
Stop registering deprecated relay publish handlers

### DIFF
--- a/js/nostrPublish.js
+++ b/js/nostrPublish.js
@@ -116,9 +116,16 @@ export function publishEventToRelay(pool, url, event, options = {}) {
         handlerRegistered =
           registerHandler("ok", handleSuccess) || handlerRegistered;
         handlerRegistered =
-          registerHandler("seen", handleSuccess) || handlerRegistered;
-        handlerRegistered =
           registerHandler("failed", handleFailure) || handlerRegistered;
+
+        // nostr-tools@1.8 removed the optional "seen" callback from relay
+        // publish handles. Attempting to register it now produces an
+        // asynchronous TypeError that bubbles up as an unhandled rejection and
+        // prevents watch-history snapshots from ever resolving. We therefore
+        // skip registering a "seen" listener and rely on "ok" (per NIP-20) for
+        // success notifications. Legacy relays that only emit "seen" fall back
+        // to the optimistic success path below because no handlers end up
+        // registered.
 
         if (handlerRegistered) {
           return;


### PR DESCRIPTION
## Summary
- stop registering the deprecated `seen` handler when publishing to relays so nostr-tools 1.8 no longer throws
- document the change so future agents know why `ok` is the only handler

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68de7533cb7c832b802cd4cad2909ed0