### PR TITLE
Add watch history removal actions and metadata synchronization

### DIFF
--- a/js/watchHistoryService.js
+++ b/js/watchHistoryService.js
@@ -1086,6 +1086,17 @@ function getAllQueues() {
   return summary;
 }
 
+function getSettings() {
+  const preference = getMetadataPreference();
+  return {
+    metadata: {
+      preference,
+      storeLocally: preference === true,
+      cacheSize: state.metadata.cache.size,
+    },
+  };
+}
+
 const watchHistoryService = {
   isEnabled: isFeatureEnabled,
   publishView,
@@ -1102,6 +1113,7 @@ const watchHistoryService = {
   setLocalMetadata,
   removeLocalMetadata,
   clearLocalMetadata,
+  getSettings,
   subscribe,
 };
 


### PR DESCRIPTION
## Summary
- add a dedicated watch-history removal action to video cards and ensure pointer metadata is captured when available
- centralize watch-history metadata preference handling and shared removal logic in the app layer for both modal and standalone contexts
- update history view buttons with enriched accessibility copy and route removals through the shared handler

## Testing
- npm test -- --runTestsByPath tests/watchHistory.test.js *(fails: missing npm "test" script)*

------
https://chatgpt.com/codex/tasks/task_b_68dec7d19d38832b86a956b7b31a9074