### PR TITLE
Refactor video UI component orchestration

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -795,7 +795,7 @@ async function loadUserVideos(pubkey) {
       app.handleUrlHealthBadge({ video, url, badgeEl });
     });
 
-    window.app.attachVideoListHandler();
+    window.app.mountVideoListView();
 
     // Lazy-load images
     const lazyEls = container.querySelectorAll("[data-lazy]");

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -704,7 +704,7 @@ class SubscriptionsManager {
       window.app.handleUrlHealthBadge({ video, url, badgeEl });
     });
 
-    window.app?.attachVideoListHandler?.();
+    window.app?.mountVideoListView?.();
 
     // Lazy-load
     const lazyEls = container.querySelectorAll("[data-lazy]");

--- a/js/ui/views/VideoListView.js
+++ b/js/ui/views/VideoListView.js
@@ -18,6 +18,7 @@ export class VideoListView {
       assets = {},
       state = {},
       utils = {},
+      renderers = {},
     } = options;
 
     this.document = doc;
@@ -53,6 +54,13 @@ export class VideoListView {
       loadedThumbnails:
         state.loadedThumbnails instanceof Map ? state.loadedThumbnails : new Map(),
       videosMap: state.videosMap instanceof Map ? state.videosMap : new Map(),
+    };
+
+    this.renderers = {
+      getLoadingMarkup:
+        typeof renderers.getLoadingMarkup === "function"
+          ? renderers.getLoadingMarkup
+          : () => "",
     };
 
     this.utils = {
@@ -176,8 +184,28 @@ export class VideoListView {
     }
   }
 
-  destroy() {
+  mount(container) {
+    this.setContainer(container);
+    return this.container;
+  }
+
+  unmount() {
     this.setContainer(null);
+  }
+
+  showLoading(message = "") {
+    if (!this.container) {
+      return;
+    }
+
+    const markup = this.renderers.getLoadingMarkup(message);
+    if (typeof markup === "string") {
+      this.container.innerHTML = markup;
+    }
+  }
+
+  destroy() {
+    this.unmount();
     this.teardownAllViewCountSubscriptions();
     this.renderedVideoIds.clear();
     this.videoCardInstances = [];

--- a/js/viewManager.js
+++ b/js/viewManager.js
@@ -53,9 +53,8 @@ export async function loadView(viewUrl) {
 export const viewInitRegistry = {
   "most-recent-videos": () => {
     if (window.app && window.app.loadVideos) {
-      window.app.videoList = document.getElementById("videoList");
-      if (window.app.attachVideoListHandler) {
-        window.app.attachVideoListHandler();
+      if (typeof window.app.mountVideoListView === "function") {
+        window.app.mountVideoListView();
       }
       window.app.loadVideos();
     }


### PR DESCRIPTION
## Summary
- wire the upload, edit, revert, and playback components directly into the app orchestrator with stored handlers
- add mount and loading helpers to `VideoListView` and update view loaders to rely on the component API
- provide teardown hooks so component listeners are cleaned up when the app is destroyed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e033d5c26c832ba5a8031f28a5d4d5