### PR TITLE
Add manual QA summary for 2024-05-10

### DIFF
--- a/docs/manual-qa-2024-05-10.md
+++ b/docs/manual-qa-2024-05-10.md
@@ -1,0 +1,29 @@
+# Manual QA — 2024-05-10
+
+## Scope
+* Login/logout state transitions via `authService`
+* Video list rendering and playback fallback via `playbackService`
+* Upload submissions (URL only, magnet only, combined) via `publishVideoNote`
+
+## Environment
+* Local static server: `python -m http.server 5173`
+* Browser automation: Playwright (Chromium) via sandboxed runner
+* Stubbed `window.nostr` for extension-less login flows
+
+## Results
+### Authentication
+* Pre-login upload button hidden (`False`).
+* Post-login upload button visible (`True`); profile button also visible.
+* Post-logout upload button hidden again (`False`).
+
+### Playback
+* Hosted URL attempt emitted `session-start` analytics event. Hosted playback errored in sandbox (no magnet fallback available for URL-only sample).
+* Second sample (URL + magnet) emitted `session-start`, `fallback`, `playViaWebTorrent`, and `sourcechange: torrent` events confirming magnet fallback wiring.
+
+### Upload flows
+* URL-only submission succeeded (normalized payload kept empty magnet and blank hints).
+* Magnet-only submission appended WSS tracker hints plus provided `ws`/`xs` values.
+* Combined submission retained HTTPS URL and normalized magnet with tracker hints.
+
+## Notes
+Automation invoked `app.authService.login`/`handleAuthLogin` and `app.publishVideoNote` directly to simulate modal interactions. Playback checks observed console analytics, not media rendering (hosted stream blocked by sandbox security).


### PR DESCRIPTION
## Summary
- document the 2024-05-10 manual QA run covering auth, playback fallback, and upload flows

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e15e863c7c832b9220ae15c12e3317