### PR TITLE
Integrate feed engine into recent video flow

### DIFF
--- a/js/ui/views/VideoListView.js
+++ b/js/ui/views/VideoListView.js
@@ -54,6 +54,10 @@ export class VideoListView {
       loadedThumbnails:
         state.loadedThumbnails instanceof Map ? state.loadedThumbnails : new Map(),
       videosMap: state.videosMap instanceof Map ? state.videosMap : new Map(),
+      feedMetadata:
+        state.feedMetadata && typeof state.feedMetadata === "object"
+          ? { ...state.feedMetadata }
+          : null,
     };
 
     this.renderers = {
@@ -234,7 +238,7 @@ export class VideoListView {
     this.handlers.blacklist = typeof handler === "function" ? handler : null;
   }
 
-  render(videos) {
+  render(videos, metadata = null) {
     if (!this.container) {
       return [];
     }
@@ -243,6 +247,10 @@ export class VideoListView {
       this.lastRenderedVideoSignature = null;
       this._lastRenderedVideoListElement = this.container;
     }
+
+    const normalizedMetadata =
+      metadata && typeof metadata === "object" ? { ...metadata } : null;
+    this.state.feedMetadata = normalizedMetadata;
 
     const source = Array.isArray(videos) ? videos : [];
     const dedupedVideos = this.utils.dedupeVideos(source);
@@ -471,7 +479,7 @@ export class VideoListView {
 
     this.currentVideos[index] = next;
     this.state.videosMap.set(videoId, next);
-    this.render(this.currentVideos.slice());
+    this.render(this.currentVideos.slice(), this.state.feedMetadata);
     return next;
   }
 


### PR DESCRIPTION
## Summary
- instantiate the feed engine during application setup and register a recent feed mirroring the existing nostr video pipeline
- switch recent video loading and pagination over to the shared feed engine while preserving callbacks and metadata handling
- allow VideoListView to store feed metadata and extend feed engine tests to cover blacklist ordering changes

## Testing
- node tests/feed-engine.test.mjs
- node tests/view-counter.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e182ccd2e8832b80382b1cf402941b