### PR TITLE
Add watch history feed adapter and UI integration

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -25,6 +25,7 @@ import {
   createDedupeByRootStage,
   createChronologicalSorter,
   createSubscriptionAuthorsSource,
+  registerWatchHistoryFeed,
 } from "./feedEngine/index.js";
 import watchHistoryService from "./watchHistoryService.js";
 import r2Service from "./services/r2Service.js";
@@ -186,6 +187,7 @@ class Application {
     }
     this.registerRecentFeed();
     this.registerSubscriptionsFeed();
+    this.registerWatchHistoryFeed();
 
     this.playbackService =
       services.playbackService ||
@@ -4993,6 +4995,30 @@ class Application {
       });
     } catch (error) {
       console.warn("[Application] Failed to register subscriptions feed:", error);
+      return null;
+    }
+  }
+
+  registerWatchHistoryFeed() {
+    if (!this.feedEngine || typeof this.feedEngine.registerFeed !== "function") {
+      return null;
+    }
+
+    const existingDefinition =
+      typeof this.feedEngine.getFeedDefinition === "function"
+        ? this.feedEngine.getFeedDefinition("watch-history")
+        : null;
+    if (existingDefinition) {
+      return existingDefinition;
+    }
+
+    try {
+      return registerWatchHistoryFeed(this.feedEngine, {
+        service: watchHistoryService,
+        nostr: this.nostrService,
+      });
+    } catch (error) {
+      console.warn("[Application] Failed to register watch history feed:", error);
       return null;
     }
   }

--- a/js/feedEngine/index.js
+++ b/js/feedEngine/index.js
@@ -16,3 +16,4 @@ export {
   createSubscriptionAuthorsSource,
   createWatchHistoryPointerSource,
 } from "./sources.js";
+export { createWatchHistoryFeedDefinition, registerWatchHistoryFeed } from "./watchHistoryFeed.js";

--- a/js/feedEngine/watchHistoryFeed.js
+++ b/js/feedEngine/watchHistoryFeed.js
@@ -137,19 +137,14 @@ function createWatchHistorySource({ service = watchHistoryService } = {}) {
       items = [];
     }
 
-    const map = new Map();
+    const results = [];
     for (const raw of Array.isArray(items) ? items : []) {
       const normalized = normalizeHistoryEntry(raw);
-      if (!normalized) {
-        continue;
-      }
-      const existing = map.get(normalized.pointerKey);
-      if (!existing || existing.watchedAt < normalized.watchedAt) {
-        map.set(normalized.pointerKey, normalized);
+      if (normalized) {
+        results.push(normalized);
       }
     }
 
-    const results = Array.from(map.values());
     results.sort((a, b) => {
       if (a.watchedAt !== b.watchedAt) {
         return b.watchedAt - a.watchedAt;

--- a/js/feedEngine/watchHistoryFeed.js
+++ b/js/feedEngine/watchHistoryFeed.js
@@ -1,0 +1,342 @@
+// js/feedEngine/watchHistoryFeed.js
+
+import { pointerKey, normalizePointerInput } from "../nostr.js";
+import watchHistoryService from "../watchHistoryService.js";
+import nostrService from "../services/nostrService.js";
+import { createWatchHistoryMetadataResolver } from "../watchHistoryMetadata.js";
+import {
+  createBlacklistFilterStage,
+  createWatchHistorySuppressionStage,
+} from "./stages.js";
+import { isPlainObject } from "./utils.js";
+
+function normalizeActorCandidate(...values) {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
+function resolveWatchedAt(...candidates) {
+  for (const candidate of candidates) {
+    if (!Number.isFinite(candidate)) {
+      continue;
+    }
+    let normalized = Math.floor(Number(candidate));
+    if (normalized <= 0) {
+      continue;
+    }
+    if (normalized > 10_000_000_000) {
+      normalized = Math.floor(normalized / 1000);
+    }
+    if (normalized > 0) {
+      return normalized;
+    }
+  }
+  return 0;
+}
+
+function resolveResumeSeconds(candidate) {
+  const candidates = [
+    candidate?.resumeSeconds,
+    candidate?.resume,
+    candidate?.resumeAt,
+    candidate?.resumePosition,
+    candidate?.resumeTime,
+    candidate?.progress?.resume,
+    candidate?.progress?.seconds,
+    candidate?.progress?.position,
+    candidate?.pointer?.resumeSeconds,
+    candidate?.pointer?.resume,
+    candidate?.pointer?.resumeAt,
+  ];
+
+  for (const entry of candidates) {
+    if (!Number.isFinite(entry)) {
+      continue;
+    }
+    const normalized = Math.max(0, Math.floor(entry));
+    if (normalized > 0) {
+      return normalized;
+    }
+  }
+  return null;
+}
+
+function resolveCompleted(candidate) {
+  const candidates = [
+    candidate?.completed,
+    candidate?.complete,
+    candidate?.progress?.completed,
+    candidate?.progress?.complete,
+    candidate?.pointer?.completed,
+    candidate?.pointer?.complete,
+  ];
+  return candidates.some((value) => value === true);
+}
+
+function normalizeHistoryEntry(raw) {
+  const pointer = normalizePointerInput(raw?.pointer || raw);
+  if (!pointer) {
+    return null;
+  }
+
+  const key = pointerKey(pointer);
+  if (!key) {
+    return null;
+  }
+
+  const watchedAt = resolveWatchedAt(
+    raw?.watchedAt,
+    raw?.timestamp,
+    raw?.created_at,
+    pointer?.watchedAt,
+  );
+
+  const resumeAt = resolveResumeSeconds(raw);
+  const completed = resolveCompleted(raw);
+
+  return {
+    pointer,
+    pointerKey: key,
+    watchedAt,
+    video: isPlainObject(raw?.video) ? raw.video : null,
+    metadata: {
+      source: "watch-history",
+      pointerKey: key,
+      watchedAt,
+      resumeAt,
+      completed,
+      session: raw?.session === true || pointer.session === true,
+    },
+  };
+}
+
+function createWatchHistorySource({ service = watchHistoryService } = {}) {
+  return async function watchHistorySource(context = {}) {
+    const actor = normalizeActorCandidate(
+      context?.runtime?.watchHistory?.actor,
+      context?.config?.actor,
+      context?.runtime?.actor,
+    );
+
+    if (!service || typeof service.loadLatest !== "function") {
+      return [];
+    }
+
+    let items = [];
+    try {
+      items = await Promise.resolve(service.loadLatest(actor || undefined));
+    } catch (error) {
+      context?.log?.("[watch-history-feed] Failed to load history", error);
+      items = [];
+    }
+
+    const map = new Map();
+    for (const raw of Array.isArray(items) ? items : []) {
+      const normalized = normalizeHistoryEntry(raw);
+      if (!normalized) {
+        continue;
+      }
+      const existing = map.get(normalized.pointerKey);
+      if (!existing || existing.watchedAt < normalized.watchedAt) {
+        map.set(normalized.pointerKey, normalized);
+      }
+    }
+
+    const results = Array.from(map.values());
+    results.sort((a, b) => {
+      if (a.watchedAt !== b.watchedAt) {
+        return b.watchedAt - a.watchedAt;
+      }
+      return a.pointerKey.localeCompare(b.pointerKey);
+    });
+
+    return results;
+  };
+}
+
+function createWatchHistoryHydratorStage({
+  service = watchHistoryService,
+  metadataResolver,
+} = {}) {
+  const resolver = metadataResolver || createWatchHistoryMetadataResolver();
+
+  return async function watchHistoryHydratorStage(items = [], context = {}) {
+    const shouldStoreMetadata =
+      typeof service?.shouldStoreMetadata === "function"
+        ? service.shouldStoreMetadata() !== false
+        : true;
+
+    const results = [];
+
+    for (const item of Array.isArray(items) ? items : []) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+
+      const pointerKeyValue =
+        typeof item.pointerKey === "string" && item.pointerKey
+          ? item.pointerKey
+          : pointerKey(item.pointer);
+
+      const watchedAtValue = Number.isFinite(item?.watchedAt)
+        ? Math.max(0, Math.floor(Number(item.watchedAt)))
+        : Number.isFinite(item?.metadata?.watchedAt)
+        ? Math.max(0, Math.floor(Number(item.metadata.watchedAt)))
+        : 0;
+
+      let video = item.video || null;
+      let profile = item.metadata?.profile || null;
+
+      if (pointerKeyValue && typeof service?.getLocalMetadata === "function") {
+        try {
+          const stored = service.getLocalMetadata(pointerKeyValue);
+          if (stored) {
+            video = video || stored.video || null;
+            profile = profile || stored.profile || null;
+          }
+        } catch (error) {
+          context?.log?.(
+            "[watch-history-feed] Failed to read cached metadata",
+            error,
+          );
+        }
+      }
+
+      if (!video && resolver?.resolveVideo) {
+        try {
+          video = await resolver.resolveVideo(item.pointer);
+        } catch (error) {
+          context?.log?.(
+            "[watch-history-feed] Failed to resolve video from pointer",
+            error,
+          );
+        }
+      }
+
+      if (video?.pubkey && !profile && resolver?.resolveProfile) {
+        try {
+          profile = resolver.resolveProfile(video.pubkey) || null;
+        } catch (error) {
+          context?.log?.(
+            "[watch-history-feed] Failed to resolve profile for pointer",
+            error,
+          );
+        }
+      }
+
+      const metadata = {
+        ...(isPlainObject(item.metadata) ? item.metadata : {}),
+        pointerKey: pointerKeyValue,
+        watchedAt: watchedAtValue || null,
+        resumeAt: item.metadata?.resumeAt ?? null,
+        completed: item.metadata?.completed ?? false,
+        session: item.metadata?.session === true,
+        video: video || null,
+        profile: profile || null,
+      };
+
+      const nextItem = {
+        ...item,
+        pointerKey: pointerKeyValue,
+        watchedAt: watchedAtValue,
+        video: video || null,
+        metadata,
+      };
+      results.push(nextItem);
+
+      if (pointerKeyValue) {
+        if (shouldStoreMetadata) {
+          try {
+            service?.setLocalMetadata?.(pointerKeyValue, {
+              video: metadata.video,
+              profile: metadata.profile,
+            });
+          } catch (error) {
+            context?.log?.(
+              "[watch-history-feed] Failed to persist metadata cache",
+              error,
+            );
+          }
+        } else if (typeof service?.removeLocalMetadata === "function") {
+          try {
+            service.removeLocalMetadata(pointerKeyValue);
+          } catch (error) {
+            context?.log?.(
+              "[watch-history-feed] Failed to clear cached metadata",
+              error,
+            );
+          }
+        }
+      }
+    }
+
+    return results;
+  };
+}
+
+function createWatchHistorySorter() {
+  return function watchHistorySorter(items = []) {
+    if (!Array.isArray(items)) {
+      return [];
+    }
+    const copy = [...items];
+    copy.sort((a, b) => {
+      if (a?.watchedAt !== b?.watchedAt) {
+        return (b?.watchedAt || 0) - (a?.watchedAt || 0);
+      }
+      const aKey = typeof a?.pointerKey === "string" ? a.pointerKey : "";
+      const bKey = typeof b?.pointerKey === "string" ? b.pointerKey : "";
+      return aKey.localeCompare(bKey);
+    });
+    return copy;
+  };
+}
+
+export function createWatchHistoryFeedDefinition({
+  service = watchHistoryService,
+  nostr = nostrService,
+  metadataResolverFactory = createWatchHistoryMetadataResolver,
+  shouldIncludeVideo,
+} = {}) {
+  const metadataResolver = metadataResolverFactory({ nostr });
+
+  const blacklistStage = createBlacklistFilterStage({
+    shouldIncludeVideo:
+      typeof shouldIncludeVideo === "function"
+        ? shouldIncludeVideo
+        : (video, options) =>
+            (nostr?.shouldIncludeVideo
+              ? nostr.shouldIncludeVideo(video, options)
+              : true),
+  });
+
+  return {
+    source: createWatchHistorySource({ service }),
+    stages: [
+      createWatchHistoryHydratorStage({ service, metadataResolver }),
+      blacklistStage,
+      createWatchHistorySuppressionStage(),
+    ],
+    sorter: createWatchHistorySorter(),
+    defaultConfig: {
+      actorFilters: [],
+    },
+  };
+}
+
+export function registerWatchHistoryFeed(engine, options = {}) {
+  if (!engine || typeof engine.registerFeed !== "function") {
+    return null;
+  }
+
+  const definition = createWatchHistoryFeedDefinition(options);
+  return engine.registerFeed("watch-history", definition);
+}
+

--- a/js/watchHistoryMetadata.js
+++ b/js/watchHistoryMetadata.js
@@ -1,0 +1,267 @@
+// js/watchHistoryMetadata.js
+
+import { getApplication } from "./applicationContext.js";
+import nostrService from "./services/nostrService.js";
+import { nostrClient } from "./nostr.js";
+
+const isDevEnv =
+  typeof process !== "undefined" && process?.env?.NODE_ENV !== "production";
+
+function normalizeVideoCandidate(candidate) {
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+  if (candidate.deleted) {
+    return null;
+  }
+  return candidate;
+}
+
+export function createWatchHistoryMetadataResolver({
+  appResolver = getApplication,
+  nostr = nostrService,
+  client = nostrClient,
+} = {}) {
+  const caches = {
+    activeVideos: null,
+    catalogPromise: null,
+  };
+
+  function getAppInstance() {
+    try {
+      return typeof appResolver === "function" ? appResolver() : getApplication();
+    } catch (error) {
+      if (isDevEnv) {
+        console.warn(
+          "[watchHistoryMetadata] Failed to resolve application instance:",
+          error,
+        );
+      }
+      return null;
+    }
+  }
+
+  async function resolveVideo(pointer) {
+    if (!pointer || typeof pointer !== "object") {
+      return null;
+    }
+
+    const app = getAppInstance();
+    const type = pointer.type === "a" ? "a" : "e";
+    const value = typeof pointer.value === "string" ? pointer.value.trim() : "";
+    if (!value) {
+      return null;
+    }
+
+    if (type === "e") {
+      const fromAppCache = app?.videosMap?.get?.(value);
+      const normalizedAppCache = normalizeVideoCandidate(fromAppCache);
+      if (normalizedAppCache) {
+        return normalizedAppCache;
+      }
+
+      const fromClientCache = client?.allEvents instanceof Map
+        ? client.allEvents.get(value)
+        : null;
+      const normalizedClientCache = normalizeVideoCandidate(fromClientCache);
+      if (normalizedClientCache) {
+        return normalizedClientCache;
+      }
+
+      if (typeof app?.getOldEventById === "function") {
+        try {
+          const fetched = await app.getOldEventById(value);
+          const normalized = normalizeVideoCandidate(fetched);
+          if (normalized) {
+            return normalized;
+          }
+        } catch (error) {
+          if (isDevEnv) {
+            console.warn(
+              "[watchHistoryMetadata] Failed to fetch old event by id:",
+              error,
+            );
+          }
+        }
+      }
+
+      if (typeof client?.getEventById === "function") {
+        try {
+          const fetched = await client.getEventById(value);
+          const normalized = normalizeVideoCandidate(fetched);
+          if (normalized) {
+            return normalized;
+          }
+        } catch (error) {
+          if (isDevEnv) {
+            console.warn(
+              "[watchHistoryMetadata] Failed to fetch event by id:",
+              error,
+            );
+          }
+        }
+      }
+
+      return null;
+    }
+
+    const compareAddress = (candidate) => {
+      if (!candidate || typeof candidate !== "object") {
+        return false;
+      }
+      if (typeof app?.getVideoAddressPointer !== "function") {
+        return false;
+      }
+      try {
+        const address = app.getVideoAddressPointer(candidate);
+        return typeof address === "string" && address.trim() === value;
+      } catch (error) {
+        if (isDevEnv) {
+          console.warn(
+            "[watchHistoryMetadata] Failed to compute address pointer:",
+            error,
+          );
+        }
+      }
+      return false;
+    };
+
+    if (app?.videosMap instanceof Map) {
+      for (const cached of app.videosMap.values()) {
+        if (compareAddress(cached)) {
+          const normalized = normalizeVideoCandidate(cached);
+          if (normalized) {
+            return normalized;
+          }
+        }
+      }
+    }
+
+    const blacklist = app?.blacklistedEventIds instanceof Set
+      ? app.blacklistedEventIds
+      : undefined;
+    const filterOptions = {
+      blacklistedEventIds: blacklist,
+      isAuthorBlocked: (pubkey) => {
+        try {
+          return (
+            typeof app?.isAuthorBlocked === "function" &&
+            app.isAuthorBlocked(pubkey)
+          );
+        } catch (error) {
+          if (isDevEnv) {
+            console.warn(
+              "[watchHistoryMetadata] Failed to evaluate isAuthorBlocked:",
+              error,
+            );
+          }
+          return false;
+        }
+      },
+    };
+
+    if (!Array.isArray(caches.activeVideos)) {
+      try {
+        caches.activeVideos = nostr.getFilteredActiveVideos
+          ? nostr.getFilteredActiveVideos(filterOptions)
+          : [];
+      } catch (error) {
+        if (isDevEnv) {
+          console.warn(
+            "[watchHistoryMetadata] Failed to read active videos cache:",
+            error,
+          );
+        }
+        caches.activeVideos = [];
+      }
+    }
+
+    for (const candidate of Array.isArray(caches.activeVideos)
+      ? caches.activeVideos
+      : []) {
+      if (compareAddress(candidate)) {
+        const normalized = normalizeVideoCandidate(candidate);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+
+    if (!caches.catalogPromise && typeof nostr.fetchVideos === "function") {
+      caches.catalogPromise = nostr
+        .fetchVideos(filterOptions)
+        .catch((error) => {
+          if (isDevEnv) {
+            console.warn(
+              "[watchHistoryMetadata] Failed to fetch video catalog:",
+              error,
+            );
+          }
+          return [];
+        });
+    }
+
+    if (caches.catalogPromise) {
+      try {
+        const catalog = await caches.catalogPromise;
+        for (const candidate of Array.isArray(catalog) ? catalog : []) {
+          if (compareAddress(candidate)) {
+            const normalized = normalizeVideoCandidate(candidate);
+            if (normalized) {
+              return normalized;
+            }
+          }
+        }
+      } catch (error) {
+        if (isDevEnv) {
+          console.warn(
+            "[watchHistoryMetadata] Failed to resolve catalog pointer:",
+            error,
+          );
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function resolveProfile(pubkey) {
+    if (typeof pubkey !== "string" || !pubkey.trim()) {
+      return null;
+    }
+    const app = getAppInstance();
+    if (!app) {
+      return null;
+    }
+    try {
+      const cacheEntry =
+        typeof app.getProfileCacheEntry === "function"
+          ? app.getProfileCacheEntry(pubkey)
+          : null;
+      if (cacheEntry && typeof cacheEntry === "object") {
+        return cacheEntry.profile || null;
+      }
+    } catch (error) {
+      if (isDevEnv) {
+        console.warn(
+          "[watchHistoryMetadata] Failed to read profile cache entry:",
+          error,
+        );
+      }
+    }
+    return null;
+  }
+
+  function reset() {
+    caches.activeVideos = null;
+    caches.catalogPromise = null;
+  }
+
+  return {
+    resolveVideo,
+    resolveProfile,
+    reset,
+    caches,
+  };
+}
+

--- a/tests/watch-history-feed.test.mjs
+++ b/tests/watch-history-feed.test.mjs
@@ -1,0 +1,132 @@
+// Run with: node tests/watch-history-feed.test.mjs
+
+import assert from "node:assert/strict";
+
+if (typeof globalThis.window === "undefined") {
+  globalThis.window = {};
+}
+
+const noopStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+};
+
+if (typeof globalThis.localStorage === "undefined") {
+  globalThis.localStorage = noopStorage;
+}
+
+if (typeof window.localStorage === "undefined") {
+  window.localStorage = globalThis.localStorage;
+}
+
+const { createFeedEngine, registerWatchHistoryFeed } = await import(
+  "../js/feedEngine/index.js"
+);
+
+function createStubService(history = []) {
+  let loadCount = 0;
+  return {
+    get loadCount() {
+      return loadCount;
+    },
+    loadLatest: async () => {
+      loadCount += 1;
+      return history.map((entry) => ({ ...entry }));
+    },
+    setHistory(next) {
+      history = Array.isArray(next) ? next : [];
+    },
+    shouldStoreMetadata: () => false,
+    getLocalMetadata: () => null,
+    setLocalMetadata: () => {},
+    removeLocalMetadata: () => {},
+  };
+}
+
+function createResolverFactory() {
+  return () => ({
+    resolveVideo: async () => null,
+    resolveProfile: () => null,
+  });
+}
+
+async function testOrderingByWatchedAt() {
+  const service = createStubService([
+    {
+      pointer: { type: "e", value: "earlier" },
+      watchedAt: 100,
+    },
+    {
+      pointer: { type: "e", value: "latest" },
+      watchedAt: 200,
+    },
+  ]);
+
+  const engine = createFeedEngine();
+  registerWatchHistoryFeed(engine, {
+    service,
+    nostr: { shouldIncludeVideo: () => true },
+    metadataResolverFactory: createResolverFactory(),
+  });
+
+  const result = await engine.runFeed("watch-history", {
+    runtime: { watchHistory: { actor: "npub-order" } },
+  });
+
+  assert.equal(result.items.length, 2, "feed should include two watch history entries");
+  assert.equal(
+    result.items[0].metadata.pointerKey,
+    "e:latest",
+    "newest watch event should be first in the feed",
+  );
+  assert.equal(
+    result.items[1].metadata.pointerKey,
+    "e:earlier",
+    "older watch event should be last in the feed",
+  );
+  assert.ok(
+    result.items[0].metadata.watchedAt >= result.items[1].metadata.watchedAt,
+    "items should be sorted by watchedAt descending",
+  );
+}
+
+async function testRemovalRefreshesSource() {
+  const initialHistory = [
+    { pointer: { type: "e", value: "keep" }, watchedAt: 300 },
+    { pointer: { type: "e", value: "remove" }, watchedAt: 250 },
+  ];
+  const service = createStubService(initialHistory);
+  const engine = createFeedEngine();
+  registerWatchHistoryFeed(engine, {
+    service,
+    nostr: { shouldIncludeVideo: () => true },
+    metadataResolverFactory: createResolverFactory(),
+  });
+
+  const firstRun = await engine.runFeed("watch-history", {
+    runtime: { watchHistory: { actor: "npub-refresh" } },
+  });
+  assert.equal(firstRun.items.length, 2, "initial run should return full history");
+  assert.equal(service.loadCount, 1, "loadLatest should be invoked for the initial run");
+
+  service.setHistory([{ pointer: { type: "e", value: "keep" }, watchedAt: 300 }]);
+
+  const secondRun = await engine.runFeed("watch-history", {
+    runtime: { watchHistory: { actor: "npub-refresh" } },
+  });
+
+  assert.equal(service.loadCount, 2, "engine should request fresh history after change");
+  assert.equal(secondRun.items.length, 1, "second run should reflect updated history");
+  assert.equal(
+    secondRun.items[0].metadata.pointerKey,
+    "e:keep",
+    "remaining pointer should persist after refresh",
+  );
+}
+
+await testOrderingByWatchedAt();
+await testRemovalRefreshesSource();
+
+console.log("watch-history-feed.test.mjs completed successfully.");


### PR DESCRIPTION
## Summary
- add a watch history feed pipeline that normalizes pointers, hydrates metadata, and exposes registration helpers
- update the history view to execute the engine feed, reuse shared metadata caches, and refresh after removals
- extract reusable watch history metadata resolver utilities and add coverage for feed ordering and refresh behavior

## Testing
- node tests/feed-engine.test.mjs
- node tests/watch-history-feed.test.mjs
- node tests/watch-history.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e18c8cc2cc832b84aee537e9e5a66f