### PR TITLE
Add NIP-71 publishing pipeline alongside legacy video notes

### DIFF
--- a/docs/nostr-event-schemas.md
+++ b/docs/nostr-event-schemas.md
@@ -47,6 +47,8 @@ read/write split.
 | --- | --- | --- | --- |
 | Video post (`NOTE_TYPES.VIDEO_POST`) | `30078` | `['t','video']`, `['d', <stable video identifier>]` plus optional schema append tags | JSON payload using Content Schema v3 (`version`, `title`, optional `url`, `magnet`, `thumbnail`, `description`, `mode`, `videoRootId`, `deleted`, `isPrivate`, `enableComments`, `ws`, `xs`) |
 | NIP-94 mirror (`NOTE_TYPES.VIDEO_MIRROR`) | `1063` | Tags forwarded from `publishVideo` (URL, mime type, thumbnail, alt text, magnet) | Plain text alt description |
+| NIP-71 video (`NOTE_TYPES.NIP71_VIDEO`) | `21` | `['title', <title>]`, optional `['published_at', <unix seconds>]`, optional `['alt', <text>]`, repeated `['imeta', ...]` entries describing NIP-92 media variants, optional `['duration', <seconds>]`, repeated `['text-track', <url>, <kind>, <language>]`, optional `['content-warning', <reason>]`, repeated `['segment', <start>, <end>, <title>, <thumbnail>]`, repeated hashtags `['t', <tag>]`, repeated participants `['p', <pubkey>, <relay?>]`, repeated references `['r', <url>]` | Plain text summary carried in the content field. Publishing is gated by the `FEATURE_PUBLISH_NIP71` runtime flag while the rollout stabilizes. |
+| NIP-71 short video (`NOTE_TYPES.NIP71_SHORT_VIDEO`) | `22` | Same as `NOTE_TYPES.NIP71_VIDEO`; the kind differentiates short-form presentations. | Plain text summary; gated by `FEATURE_PUBLISH_NIP71`. |
 | Relay list (`NOTE_TYPES.RELAY_LIST`) | `10002` | Repeating `['r', <relay url>]` tags, optionally with a marker of `'read'` or `'write'` to scope the relay; marker omitted for read/write relays | Empty content |
 | View counter (`NOTE_TYPES.VIEW_EVENT`) | `WATCH_HISTORY_KIND` (default `30079`, clients also read legacy `30078`) | Canonical tag set: `['t','view']`, a pointer tag (`['e', <eventId>]` or `['a', <address>]`), and a stable dedupe tag `['d', <view identifier>]`, with optional `['session','true']` when a session actor signs; schema overrides may append extra tags. `['video', ...]` is supported for legacy overrides only. | Optional plaintext message |
 | Watch history index (`NOTE_TYPES.WATCH_HISTORY_INDEX`) | `WATCH_HISTORY_KIND` (default `30079`, clients also read legacy `30078`) | `['d', WATCH_HISTORY_LIST_IDENTIFIER]`, `['snapshot', <id>]`, `['chunks', <total>]`, repeated `['a', <chunk address>]` pointers plus schema append tags | JSON payload `{ snapshot, totalChunks }` (may be empty when using tags only) |
@@ -60,6 +62,16 @@ read/write split.
 If you introduce a new Nostr feature, add its schema to
 `js/nostrEventSchemas.js` so that the catalogue stays complete and so existing
 builders inherit the same debugging knobs.
+
+### NIP-71 rollout
+
+BitVid now emits a paired NIP-71 event (kind `21` for long-form, `22` for short
+form) whenever the `FEATURE_PUBLISH_NIP71` flag is enabled. The builder converts
+structured upload metadata—image variants, captions, segments, hashtags, and
+participant pointers—into canonical tags so other clients can discover the same
+video. The legacy kind `30078` post remains the source of truth during the
+transition, and schema overrides can adjust either kind if relays need
+experimentation.
 
 ### Watch history identifiers
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -3,6 +3,7 @@ const DEFAULT_FLAGS = Object.freeze({
   ACCEPT_LEGACY_V1: true, // accept v1 magnet-only notes
   VIEW_FILTER_INCLUDE_LEGACY_VIDEO: false,
   FEATURE_WATCH_HISTORY_V2: false,
+  FEATURE_PUBLISH_NIP71: false,
   WSS_TRACKERS: Object.freeze([
     "wss://tracker.openwebtorrent.com",
     "wss://tracker.fastcast.nz",
@@ -23,6 +24,7 @@ const runtimeFlags = (() => {
     VIEW_FILTER_INCLUDE_LEGACY_VIDEO:
       DEFAULT_FLAGS.VIEW_FILTER_INCLUDE_LEGACY_VIDEO,
     FEATURE_WATCH_HISTORY_V2: DEFAULT_FLAGS.FEATURE_WATCH_HISTORY_V2,
+    FEATURE_PUBLISH_NIP71: DEFAULT_FLAGS.FEATURE_PUBLISH_NIP71,
     WSS_TRACKERS: [...DEFAULT_FLAGS.WSS_TRACKERS],
   };
   if (globalScope) {
@@ -108,6 +110,11 @@ export let FEATURE_WATCH_HISTORY_V2 = coerceBoolean(
   DEFAULT_FLAGS.FEATURE_WATCH_HISTORY_V2
 );
 
+export let FEATURE_PUBLISH_NIP71 = coerceBoolean(
+  runtimeFlags.FEATURE_PUBLISH_NIP71,
+  DEFAULT_FLAGS.FEATURE_PUBLISH_NIP71
+);
+
 export let WSS_TRACKERS = freezeTrackers(
   sanitizeTrackerList(runtimeFlags.WSS_TRACKERS)
 );
@@ -162,6 +169,20 @@ Object.defineProperty(runtimeFlags, "FEATURE_WATCH_HISTORY_V2", {
   },
 });
 
+Object.defineProperty(runtimeFlags, "FEATURE_PUBLISH_NIP71", {
+  configurable: true,
+  enumerable: true,
+  get() {
+    return FEATURE_PUBLISH_NIP71;
+  },
+  set(next) {
+    FEATURE_PUBLISH_NIP71 = coerceBoolean(
+      next,
+      DEFAULT_FLAGS.FEATURE_PUBLISH_NIP71
+    );
+  },
+});
+
 Object.defineProperty(runtimeFlags, "WSS_TRACKERS", {
   configurable: true,
   enumerable: true,
@@ -178,6 +199,7 @@ runtimeFlags.URL_FIRST_ENABLED = URL_FIRST_ENABLED;
 runtimeFlags.ACCEPT_LEGACY_V1 = ACCEPT_LEGACY_V1;
 runtimeFlags.VIEW_FILTER_INCLUDE_LEGACY_VIDEO = VIEW_FILTER_INCLUDE_LEGACY_VIDEO;
 runtimeFlags.FEATURE_WATCH_HISTORY_V2 = FEATURE_WATCH_HISTORY_V2;
+runtimeFlags.FEATURE_PUBLISH_NIP71 = FEATURE_PUBLISH_NIP71;
 runtimeFlags.WSS_TRACKERS = WSS_TRACKERS;
 
 export function setUrlFirstEnabled(next) {

--- a/js/nostrEventSchemas.js
+++ b/js/nostrEventSchemas.js
@@ -8,6 +8,8 @@ import {
 export const NOTE_TYPES = Object.freeze({
   VIDEO_POST: "videoPost",
   VIDEO_MIRROR: "videoMirror",
+  NIP71_VIDEO: "nip71Video",
+  NIP71_SHORT_VIDEO: "nip71ShortVideo",
   RELAY_LIST: "relayList",
   VIEW_EVENT: "viewEvent",
   WATCH_HISTORY_INDEX: "watchHistoryIndex",
@@ -129,6 +131,30 @@ const BASE_SCHEMAS = {
     content: {
       format: "text",
       description: "Optional alt text carried alongside hosted URL metadata.",
+    },
+  },
+  [NOTE_TYPES.NIP71_VIDEO]: {
+    type: NOTE_TYPES.NIP71_VIDEO,
+    label: "NIP-71 video (normal)",
+    kind: 21,
+    featureFlag: "FEATURE_PUBLISH_NIP71",
+    appendTags: DEFAULT_APPEND_TAGS,
+    content: {
+      format: "text",
+      description:
+        "Summary or description for the video body; tags carry structured metadata.",
+    },
+  },
+  [NOTE_TYPES.NIP71_SHORT_VIDEO]: {
+    type: NOTE_TYPES.NIP71_SHORT_VIDEO,
+    label: "NIP-71 video (short)",
+    kind: 22,
+    featureFlag: "FEATURE_PUBLISH_NIP71",
+    appendTags: DEFAULT_APPEND_TAGS,
+    content: {
+      format: "text",
+      description:
+        "Summary or description for the short-form video; structured fields live in tags.",
     },
   },
   [NOTE_TYPES.RELAY_LIST]: {

--- a/js/services/nostrService.js
+++ b/js/services/nostrService.js
@@ -357,8 +357,7 @@ export class NostrService {
   }
 
   async publishVideoNote(publishPayload, pubkey) {
-    const result = await this.nostrClient.publishVideo(publishPayload, pubkey);
-    const detail = { pubkey, result };
+    const detail = { pubkey };
     if (publishPayload && typeof publishPayload === "object") {
       detail.payload = publishPayload;
       if (publishPayload.legacyFormData) {
@@ -370,6 +369,26 @@ export class NostrService {
     } else {
       detail.formData = publishPayload;
     }
+
+    let nip71Result = null;
+    let legacyResult = null;
+
+    try {
+      nip71Result = await this.nostrClient.publishNip71Video(
+        publishPayload,
+        pubkey
+      );
+      legacyResult = await this.nostrClient.publishVideo(
+        publishPayload,
+        pubkey
+      );
+    } catch (error) {
+      detail.error = error;
+      throw error;
+    }
+
+    const result = { legacy: legacyResult, nip71: nip71Result };
+    detail.result = result;
     this.emit("videos:published", detail);
     return result;
   }

--- a/tests/nip71-builder.test.mjs
+++ b/tests/nip71-builder.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildNip71VideoEvent } from "../js/nostr.js";
+
+test("buildNip71VideoEvent assembles rich metadata", () => {
+  const metadata = {
+    kind: 21,
+    summary: "Custom summary",
+    publishedAt: "1700000000",
+    alt: "Alt text for accessibility",
+    duration: 123,
+    contentWarning: "Flashing lights",
+    imeta: [
+      {
+        dim: "1920x1080",
+        url: "https://cdn.example/video-1080.mp4",
+        x: "abc123",
+        m: "video/mp4",
+        image: [
+          "https://cdn.example/video-1080.jpg",
+          "https://backup.example/video-1080.jpg",
+        ],
+        fallback: ["https://fallback.example/video-1080.mp4"],
+        service: ["nip96"],
+      },
+      {
+        url: "https://cdn.example/video-hls.m3u8",
+        m: "application/x-mpegURL",
+      },
+    ],
+    textTracks: [
+      {
+        url: "https://cdn.example/captions-en.vtt",
+        type: "captions",
+        language: "en",
+      },
+      {
+        url: "https://cdn.example/captions-es.vtt",
+        language: "es",
+      },
+    ],
+    segments: [
+      { start: "00:00:00", end: "00:01:00", title: "Intro" },
+      { start: 120, title: "Middle" },
+    ],
+    hashtags: ["bitvid", "nostr"],
+    participants: [
+      { pubkey: "a".repeat(64), relay: "wss://relay.example" },
+      { pubkey: "b".repeat(64) },
+    ],
+    references: [
+      "https://example.com/info",
+      "https://example.com/docs",
+    ],
+  };
+
+  const event = buildNip71VideoEvent({
+    metadata,
+    pubkey: "f".repeat(64),
+    title: "Test Video",
+    summaryFallback: "Fallback summary",
+    createdAt: 42,
+  });
+
+  assert.ok(event, "builder should return an event");
+  assert.equal(event.kind, 21, "kind should honor metadata");
+  assert.equal(event.pubkey, "f".repeat(64));
+  assert.equal(event.created_at, 42);
+  assert.equal(event.content, "Custom summary");
+
+  const tags = new Map(event.tags.map((tag) => [tag[0], tag]));
+  assert.deepEqual(tags.get("title"), ["title", "Test Video"]);
+  assert.deepEqual(tags.get("published_at"), ["published_at", "1700000000"]);
+  assert.deepEqual(tags.get("alt"), ["alt", "Alt text for accessibility"]);
+  assert.deepEqual(tags.get("duration"), ["duration", "123"]);
+  assert.deepEqual(tags.get("content-warning"), [
+    "content-warning",
+    "Flashing lights",
+  ]);
+
+  const imetaTags = event.tags.filter((tag) => tag[0] === "imeta");
+  assert.equal(imetaTags.length, 2, "should include both imeta variants");
+  assert.deepEqual(imetaTags[0], [
+    "imeta",
+    "dim 1920x1080",
+    "url https://cdn.example/video-1080.mp4",
+    "x abc123",
+    "m video/mp4",
+    "image https://cdn.example/video-1080.jpg",
+    "image https://backup.example/video-1080.jpg",
+    "fallback https://fallback.example/video-1080.mp4",
+    "service nip96",
+  ]);
+  assert.deepEqual(imetaTags[1], [
+    "imeta",
+    "url https://cdn.example/video-hls.m3u8",
+    "m application/x-mpegURL",
+  ]);
+
+  const textTrackTags = event.tags.filter((tag) => tag[0] === "text-track");
+  assert.deepEqual(textTrackTags, [
+    [
+      "text-track",
+      "https://cdn.example/captions-en.vtt",
+      "captions",
+      "en",
+    ],
+    ["text-track", "https://cdn.example/captions-es.vtt", "", "es"],
+  ]);
+
+  const segmentTags = event.tags.filter((tag) => tag[0] === "segment");
+  assert.deepEqual(segmentTags, [
+    ["segment", "00:00:00", "00:01:00", "Intro"],
+    ["segment", "120", "", "Middle"],
+  ]);
+
+  const hashtagTags = event.tags.filter((tag) => tag[0] === "t");
+  assert.deepEqual(hashtagTags, [
+    ["t", "bitvid"],
+    ["t", "nostr"],
+  ]);
+
+  const participantTags = event.tags.filter((tag) => tag[0] === "p");
+  assert.deepEqual(participantTags, [
+    ["p", "a".repeat(64), "wss://relay.example"],
+    ["p", "b".repeat(64)],
+  ]);
+
+  const referenceTags = event.tags.filter((tag) => tag[0] === "r");
+  assert.deepEqual(referenceTags, [
+    ["r", "https://example.com/info"],
+    ["r", "https://example.com/docs"],
+  ]);
+});
+
+test("buildNip71VideoEvent falls back to summary and selects kind", () => {
+  const metadata = {
+    kind: "22",
+    publishedAt: "2024-01-01T12:00:00Z",
+    imeta: [{ url: "https://cdn.example/video.mp4" }],
+  };
+
+  const event = buildNip71VideoEvent({
+    metadata,
+    pubkey: "c".repeat(64),
+    title: "Fallback Title",
+    summaryFallback: "Fallback description",
+    createdAt: 100,
+  });
+
+  assert.ok(event, "builder should create minimal event");
+  assert.equal(event.kind, 22, "string kind should coerce to number");
+  const expectedPublished = String(Math.floor(Date.parse("2024-01-01T12:00:00Z") / 1000));
+  assert.deepEqual(event.tags.find((tag) => tag[0] === "published_at"), [
+    "published_at",
+    expectedPublished,
+  ]);
+  assert.equal(
+    event.content,
+    "Fallback description",
+    "should use fallback summary when metadata summary missing"
+  );
+});


### PR DESCRIPTION
## Summary
- add a reusable NIP-71 video event builder plus publish helper utilities, gated behind FEATURE_PUBLISH_NIP71
- update nostrService to emit both the new NIP-71 events and existing 30078 notes with shared signing/publish error handling, and document the schema additions
- extend nostr constants/docs and add targeted tests for NIP-71 tag assembly

## Testing
- node --test tests/nip71-builder.test.mjs
- node --test tests/nostr-publish-rejection.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e1a4e7f7c8832bac715a36eeea2d32