### PR TITLE
Enhance video modal zap flow and add integration tests

### DIFF
--- a/components/video-modal.html
+++ b/components/video-modal.html
@@ -167,6 +167,89 @@
           </p>
         </div>
 
+        <!-- Zap dialog -->
+        <div id="modalZapDialog" class="hidden mt-4" aria-hidden="true">
+          <div
+            class="w-full rounded-lg bg-gray-900 bg-opacity-70 p-4 shadow-lg backdrop-blur"
+          >
+            <div class="flex items-center justify-between mb-3">
+              <h3
+                class="text-xs font-semibold uppercase tracking-wide text-gray-300"
+              >
+                Send a zap
+              </h3>
+              <button
+                type="button"
+                id="modalZapCloseBtn"
+                class="text-gray-400 hover:text-gray-200 transition-colors"
+                aria-label="Close zap dialog"
+              >
+                ✕
+              </button>
+            </div>
+            <form id="modalZapForm" class="space-y-3">
+              <div>
+                <label
+                  for="modalZapAmountInput"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-300 mb-2"
+                >
+                  Zap amount (sats)
+                </label>
+                <input
+                  id="modalZapAmountInput"
+                  type="number"
+                  min="1"
+                  step="1"
+                  inputmode="numeric"
+                  class="w-full rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  placeholder="Enter sats"
+                />
+              </div>
+              <div>
+                <label
+                  for="modalZapCommentInput"
+                  class="block text-xs font-semibold uppercase tracking-wide text-gray-300 mb-2"
+                >
+                  Comment (optional)
+                </label>
+                <textarea
+                  id="modalZapCommentInput"
+                  rows="2"
+                  maxlength="280"
+                  class="w-full resize-y rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  placeholder="Include a note with your zap"
+                ></textarea>
+              </div>
+              <p
+                id="modalZapSplitSummary"
+                class="text-sm text-gray-300"
+                aria-live="polite"
+              >
+                Enter an amount to view the split.
+              </p>
+              <p
+                id="modalZapStatus"
+                class="text-xs text-gray-400"
+                role="status"
+                aria-live="polite"
+              ></p>
+              <ul
+                id="modalZapReceipts"
+                class="space-y-2 text-xs text-gray-300"
+              ></ul>
+              <div class="flex items-center justify-end gap-2">
+                <button
+                  type="submit"
+                  id="modalZapSendBtn"
+                  class="rounded bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900"
+                >
+                  Send zap
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
         <!-- Torrent stats -->
         <div class="bg-gray-800/50 rounded-lg p-4">
           <div class="w-full bg-gray-700 rounded-full h-2 mb-2">

--- a/js/payments/zapSharedState.js
+++ b/js/payments/zapSharedState.js
@@ -1,0 +1,166 @@
+import { PLATFORM_FEE_PERCENT } from "../config.js";
+import {
+  resolveLightningAddress as defaultResolveLightningAddress,
+  fetchPayServiceData as defaultFetchPayServiceData,
+  validateInvoiceAmount,
+} from "./lnurl.js";
+
+const METADATA_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const lightningMetadataCache = new Map();
+const lightningMetadataByUrl = new Map();
+let cachedPlatformLightningAddress = "";
+
+export function normalizeLightningAddressKey(address) {
+  return typeof address === "string" ? address.trim().toLowerCase() : "";
+}
+
+export function isMetadataEntryFresh(entry) {
+  if (!entry || typeof entry.fetchedAt !== "number") {
+    return false;
+  }
+  return Date.now() - entry.fetchedAt < METADATA_CACHE_TTL_MS;
+}
+
+export function rememberLightningMetadata(entry) {
+  if (!entry || !entry.key) {
+    return entry;
+  }
+  lightningMetadataCache.set(entry.key, entry);
+  if (entry.resolved?.url) {
+    lightningMetadataByUrl.set(entry.resolved.url, entry);
+  }
+  return entry;
+}
+
+export function getCachedLightningEntry(address) {
+  const key = normalizeLightningAddressKey(address);
+  if (!key) {
+    return null;
+  }
+  const entry = lightningMetadataCache.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (entry.metadata && isMetadataEntryFresh(entry)) {
+    return entry;
+  }
+  if (entry.metadata && !entry.promise) {
+    return entry;
+  }
+  return entry.metadata ? entry : null;
+}
+
+export function getCachedMetadataByUrl(url) {
+  if (!url) {
+    return null;
+  }
+  return lightningMetadataByUrl.get(url) || null;
+}
+
+export async function fetchLightningMetadata(
+  address,
+  {
+    resolveLightningAddress = defaultResolveLightningAddress,
+    fetchPayServiceData = defaultFetchPayServiceData,
+  } = {}
+) {
+  const key = normalizeLightningAddressKey(address);
+  if (!key) {
+    throw new Error("Lightning address is required.");
+  }
+
+  const cached = lightningMetadataCache.get(key);
+  if (cached && cached.metadata && isMetadataEntryFresh(cached)) {
+    return cached;
+  }
+
+  if (cached?.promise) {
+    return cached.promise;
+  }
+
+  const fetchPromise = (async () => {
+    const resolved = cached?.resolved || (await resolveLightningAddress(address));
+    const metadata = await fetchPayServiceData(resolved.url);
+    const entry = {
+      key,
+      address: resolved.address || address,
+      resolved,
+      metadata,
+      fetchedAt: Date.now(),
+    };
+    rememberLightningMetadata(entry);
+    return entry;
+  })();
+
+  lightningMetadataCache.set(key, {
+    ...(cached || {}),
+    key,
+    promise: fetchPromise,
+  });
+
+  try {
+    return await fetchPromise;
+  } catch (error) {
+    const current = lightningMetadataCache.get(key);
+    if (current?.promise === fetchPromise) {
+      lightningMetadataCache.delete(key);
+    }
+    throw error;
+  }
+}
+
+export function calculateZapShares(amount, overrideFee = null) {
+  const numericAmount = Math.max(0, Math.round(Number(amount) || 0));
+  const percentSource =
+    typeof overrideFee === "number" && Number.isFinite(overrideFee)
+      ? overrideFee
+      : PLATFORM_FEE_PERCENT;
+  const feePercent = Math.min(100, Math.max(0, Math.round(percentSource)));
+  const platformShare = Math.floor((numericAmount * feePercent) / 100);
+  const creatorShare = numericAmount - platformShare;
+  return {
+    total: numericAmount,
+    creatorShare,
+    platformShare,
+    feePercent,
+  };
+}
+
+export function describeShareType(type) {
+  if (type === "platform") {
+    return "Platform";
+  }
+  if (type === "creator") {
+    return "Creator";
+  }
+  return "Lightning";
+}
+
+export function formatMinRequirement(metadata) {
+  if (!metadata || typeof metadata.minSendable !== "number") {
+    return null;
+  }
+  if (metadata.minSendable <= 0) {
+    return null;
+  }
+  return Math.ceil(metadata.minSendable / 1000);
+}
+
+export function setCachedPlatformLightningAddress(address) {
+  cachedPlatformLightningAddress =
+    typeof address === "string" ? address.trim() : "";
+  return cachedPlatformLightningAddress;
+}
+
+export function getCachedPlatformLightningAddress() {
+  return cachedPlatformLightningAddress;
+}
+
+export function clearZapCaches() {
+  lightningMetadataCache.clear();
+  lightningMetadataByUrl.clear();
+  cachedPlatformLightningAddress = "";
+}
+
+export { validateInvoiceAmount };

--- a/tests/video-modal-zap.test.mjs
+++ b/tests/video-modal-zap.test.mjs
@@ -1,0 +1,399 @@
+import "./test-helpers/setup-localstorage.mjs";
+import assert from "node:assert/strict";
+
+const noop = () => {};
+
+class DummyElement {
+  constructor() {
+    this.classList = {
+      add: noop,
+      remove: noop,
+      toggle: noop,
+      contains: () => false,
+    };
+    this.style = {};
+    this.dataset = {};
+    this.children = [];
+  }
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+  removeChild(child) {
+    const index = this.children.indexOf(child);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+    }
+    return child;
+  }
+  querySelector() {
+    return null;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  setAttribute() {}
+  removeAttribute() {}
+  focus() {}
+  contains() {
+    return false;
+  }
+}
+
+function createDocumentStub() {
+  const doc = {
+    body: new DummyElement(),
+    documentElement: new DummyElement(),
+    head: new DummyElement(),
+    getElementById: () => null,
+    querySelector: () => null,
+    createElement: () => new DummyElement(),
+    addEventListener: noop,
+    removeEventListener: noop,
+  };
+  doc.body.contains = () => false;
+  doc.defaultView = null;
+  return doc;
+}
+
+function createWindowStub(documentStub) {
+  const nav = { clipboard: { writeText: async () => {} } };
+  const win = {
+    document: documentStub,
+    location: {
+      href: "https://example.com/",
+      origin: "https://example.com",
+      pathname: "/",
+    },
+    history: {
+      pushState: noop,
+      replaceState: noop,
+    },
+    navigator: nav,
+    addEventListener: noop,
+    removeEventListener: noop,
+    requestAnimationFrame: (fn) => {
+      if (typeof fn === "function") {
+        fn();
+      }
+    },
+    setTimeout,
+    clearTimeout,
+    NostrTools: {
+      nip19: {
+        neventEncode: () => "nevent1example",
+        npubEncode: () => "npub1example",
+        decode: (value) => {
+          if (typeof value !== "string") {
+            throw new Error("Invalid nip19 input");
+          }
+          if (value.startsWith("npub")) {
+            return { type: "npub", data: "f".repeat(64) };
+          }
+          if (value.startsWith("nevent")) {
+            return { type: "nevent", data: { id: "f".repeat(64) } };
+          }
+          return null;
+        },
+      },
+    },
+  };
+  win.HTMLElement = DummyElement;
+  win.HTMLImageElement = DummyElement;
+  win.setInterval = setInterval;
+  win.clearInterval = clearInterval;
+  win.console = console;
+  return win;
+}
+
+const documentStub = createDocumentStub();
+const windowStub = createWindowStub(documentStub);
+windowStub.document = documentStub;
+documentStub.defaultView = windowStub;
+windowStub.document.defaultView = windowStub;
+
+globalThis.__BITVID_DISABLE_NETWORK_IMPORTS__ = true;
+
+if (typeof globalThis.window === "undefined") {
+  globalThis.window = windowStub;
+} else {
+  Object.assign(globalThis.window, windowStub);
+}
+
+globalThis.HTMLElement = DummyElement;
+globalThis.HTMLImageElement = DummyElement;
+
+if (typeof globalThis.self === "undefined") {
+  globalThis.self = globalThis.window;
+} else if (globalThis.self !== globalThis.window) {
+  globalThis.self = globalThis.window;
+}
+
+if (typeof globalThis.WebSocket === "undefined") {
+  globalThis.WebSocket = class {
+    constructor() {
+      throw new Error("WebSocket is not available in tests.");
+    }
+    close() {}
+  };
+}
+
+globalThis.document = documentStub;
+globalThis.navigator = windowStub.navigator;
+globalThis.location = windowStub.location;
+
+if (typeof globalThis.fetch === "undefined") {
+  globalThis.fetch = async () => {
+    throw new Error("Unexpected fetch call in tests.");
+  };
+}
+
+const {
+  rememberLightningMetadata,
+  normalizeLightningAddressKey,
+  setCachedPlatformLightningAddress,
+  clearZapCaches,
+} = await import("../js/payments/zapSharedState.js");
+
+function primeLightningMetadata(address, overrides = {}) {
+  const key = normalizeLightningAddressKey(address);
+  rememberLightningMetadata({
+    key,
+    address,
+    resolved: { address, url: `https://lnurl.test/${address}` },
+    metadata: {
+      callback: `https://lnurl.test/${address}/callback`,
+      minSendable: 1_000,
+      maxSendable: 10_000_000,
+      commentAllowed: 280,
+      allowsNostr: true,
+      ...overrides,
+    },
+    fetchedAt: Date.now(),
+  });
+}
+
+function createVideoModalStub() {
+  const listeners = new Map();
+  return {
+    setCopyEnabled: noop,
+    setShareEnabled: noop,
+    setZapVisibility: noop,
+    resetStats: noop,
+    updateViewCountLabel: noop,
+    setViewCountPointer: noop,
+    addEventListener(type, handler) {
+      listeners.set(type, handler);
+    },
+    removeEventListener(type) {
+      listeners.delete(type);
+    },
+    setZapPendingCalls: [],
+    statusMessages: [],
+    receipts: [],
+    summaries: [],
+    resetForms: [],
+    currentAmount: "",
+    currentComment: "",
+    setZapPending(value) {
+      this.setZapPendingCalls.push(Boolean(value));
+    },
+    setZapStatus(message, tone) {
+      this.statusMessages.push({ message, tone });
+    },
+    clearZapReceipts() {
+      this.receipts.push({ cleared: true });
+    },
+    renderZapReceipts(list, options) {
+      this.receipts.push({ list, options });
+    },
+    setZapSplitSummary(text) {
+      this.summaries.push(text);
+    },
+    setZapRetryPending(pending, { summary } = {}) {
+      this.retryState = { pending, summary };
+    },
+    resetZapForm({ amount, comment }) {
+      this.resetForms.push({ amount, comment });
+      this.currentAmount = amount;
+      this.currentComment = comment;
+    },
+    setZapAmount(value) {
+      this.currentAmount = value;
+    },
+    setZapComment(value) {
+      this.currentComment = value;
+    },
+    getZapCommentValue() {
+      return this.currentComment || "";
+    },
+  };
+}
+
+function createServices({ splitAndZap }) {
+  const nostrService = {
+    getVideoSubscription: () => null,
+    getVideosMap: () => new Map(),
+    on: () => () => {},
+  };
+  const feedEngine = {
+    run: noop,
+    register: noop,
+  };
+  const playbackService = {
+    createSession: () => ({
+      getPlaybackConfig: () => ({}),
+      getMagnetForPlayback: () => "",
+    }),
+  };
+  const authService = {
+    on: () => () => {},
+  };
+  return {
+    nostrService,
+    feedEngine,
+    playbackService,
+    authService,
+    payments: {
+      splitAndZap,
+      ensureWallet: async ({ settings }) => settings,
+      sendPayment: async () => ({}),
+    },
+  };
+}
+
+function createHelpers() {
+  return {
+    mediaLoaderFactory: () => ({ observe: noop, unobserve: noop }),
+  };
+}
+
+async function createApp({ splitAndZap }) {
+  clearZapCaches();
+  const modalStub = createVideoModalStub();
+  const { Application } = await import("../js/app.js");
+  const app = new Application({
+    services: createServices({ splitAndZap }),
+    helpers: createHelpers(),
+    ui: {
+      videoModal: () => modalStub,
+    },
+  });
+
+  const creatorAddress = "creator@example.com";
+  const platformAddress = "platform@example.com";
+  setCachedPlatformLightningAddress(platformAddress);
+  primeLightningMetadata(creatorAddress);
+  primeLightningMetadata(platformAddress);
+
+  app.showError = noop;
+  app.showSuccess = noop;
+  app.showStatus = noop;
+
+  return { app, modalStub, creatorAddress, platformAddress };
+}
+
+await (async () => {
+  // Test: wallet required before zapping
+  const splitCalls = [];
+  const { app, modalStub, creatorAddress } = await createApp({
+    splitAndZap: async (...args) => {
+      splitCalls.push(args);
+      return { receipts: [] };
+    },
+  });
+
+  let walletPaneCalls = 0;
+  app.openWalletPane = () => {
+    walletPaneCalls += 1;
+  };
+
+  app.currentVideo = {
+    id: "event123",
+    pubkey: "a".repeat(64),
+    tags: [],
+    content: "",
+    created_at: 1_700_000_000,
+    lightningAddress: creatorAddress,
+  };
+
+  await app.handleVideoModalZap({
+    detail: { amount: 500, comment: "Hello" },
+  });
+
+  assert.equal(walletPaneCalls, 1, "should prompt to open wallet pane");
+  assert.equal(splitCalls.length, 0, "splitAndZap should not be invoked");
+  assert.deepEqual(modalStub.setZapPendingCalls, [], "zap controls should remain idle");
+
+  app.destroy();
+})();
+
+await (async () => {
+  // Test: splitAndZap invoked with video metadata when wallet is present
+  const splitCalls = [];
+  const splitAndZap = async (payload, deps) => {
+    splitCalls.push({ payload, deps });
+    return {
+      receipts: [
+        {
+          recipientType: "creator",
+          amount: payload.amountSats,
+          address: payload.videoEvent.lightningAddress,
+          payment: { result: { preimage: "ff".repeat(16) } },
+        },
+      ],
+    };
+  };
+  const { app, modalStub, creatorAddress } = await createApp({
+    splitAndZap,
+  });
+
+  const pubkeyHex = "b".repeat(64);
+  app.pubkey = pubkeyHex;
+  const normalized = app.normalizeHexPubkey(pubkeyHex);
+  app.nwcSettings.set(normalized, {
+    nwcUri: "nostr+walletconnect://example",
+    defaultZap: null,
+    lastChecked: null,
+    version: "",
+  });
+
+  app.currentVideo = {
+    id: "event456",
+    pubkey: pubkeyHex,
+    tags: [["d", "video123"]],
+    content: "",
+    created_at: 1_700_000_001,
+    lightningAddress: creatorAddress,
+  };
+
+  app.modalZapAmountValue = 1500;
+  app.modalZapCommentValue = "Great video";
+
+  await app.handleVideoModalZap({
+    detail: { amount: 1500, comment: "Great video" },
+  });
+
+  assert.equal(splitCalls.length, 1, "splitAndZap should be called once");
+  const call = splitCalls[0];
+  assert.equal(call.payload.amountSats, 1500);
+  assert.equal(call.payload.comment, "Great video");
+  assert.equal(
+    call.payload.videoEvent.lightningAddress,
+    creatorAddress,
+    "video event should include lightning address"
+  );
+  assert.equal(call.payload.walletSettings.nwcUri, "nostr+walletconnect://example");
+  assert.equal(call.payload.videoEvent.pubkey, pubkeyHex);
+  assert.equal(call.payload.videoEvent.id, "event456");
+  assert.deepEqual(call.payload.videoEvent.tags, [["d", "video123"]]);
+
+  const lastStatus = modalStub.statusMessages[modalStub.statusMessages.length - 1];
+  assert(lastStatus.message.includes("Sent 1500 sats"), "should report zap summary");
+  assert.equal(lastStatus.tone, "success");
+  assert.equal(modalStub.resetForms.length > 0, true, "form should reset after success");
+  assert.equal(modalStub.currentComment, "");
+
+  app.destroy();
+})();
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- add shared Lightning metadata caching utilities and refactor zap flows to consume them in the channel profile and modal handlers
- expand the video modal UI/markup to support the zap dialog with pending/receipt state management and wallet enforcement hooks
- add Node-friendly stubs plus integration tests for the modal zap handler while eliminating remote ESM imports that blocked the suite

## Testing
- node tests/video-modal-zap.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e1da3ca434832bac9597570a0aaab9