### PR TITLE
Handle namespace-style NostrTools nip04 exports for zaps

### DIFF
--- a/js/payments/nwcClient.js
+++ b/js/payments/nwcClient.js
@@ -38,7 +38,10 @@ function assertNostrTools(methods = []) {
     throw new Error("NostrTools is required for NWC operations.");
   }
   for (const method of methods) {
-    if (typeof tools?.[method] !== "function") {
+    const candidate = tools?.[method];
+    const isCallable = typeof candidate === "function";
+    const isNamespace = candidate && typeof candidate === "object";
+    if (!isCallable && !isNamespace) {
       throw new Error(`NostrTools.${method} is unavailable.`);
     }
   }


### PR DESCRIPTION
## Summary
- allow the NWC client to accept namespace-style NostrTools exports so nip04 support is detected
- prevent unnecessary zap failures when nostr-tools exposes nip04 as an object

## Testing
- node tests/zap-split.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e1ea1442b0832bac04d2e773363755