### PR TITLE
Align nostr-tools loading across app and forms

### DIFF
--- a/components/iframe_forms/iframe-application-form.html
+++ b/components/iframe_forms/iframe-application-form.html
@@ -127,8 +127,36 @@
         scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
       }
     </style>
-    <!-- Load nostr‑tools v2.10.4 -->
-    <script src="https://cdn.jsdelivr.net/npm/nostr-tools@2.10.4/lib/nostr.bundle.min.js"></script>
+    <!-- Load nostr‑tools v2.10.4 and expose nip04 for legacy consumers -->
+    <script type="module">
+      const NOSTR_TOOLS_VERSION = "2.10.4";
+
+      const loadNostrTools = async () => {
+        const nostrModule = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`);
+        const { nip04 } = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`);
+
+        const toolsBundle = {
+          ...nostrModule,
+          nip04,
+        };
+
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
+
+        return toolsBundle;
+      };
+
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
+
+      window.NostrToolsReady = nostrToolsPromise;
+    </script>
   </head>
   <body>
     <div class="container">
@@ -319,241 +347,280 @@
     </div>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        // Logging functions for both on-page and console output.
-        function log(msg, type = "info") {
-          const div = document.createElement("div");
-          div.classList.add("status-line");
-          if (type === "error") div.classList.add("error");
-          if (type === "success") div.classList.add("success");
-          if (type === "warn") div.classList.add("warn");
-          div.textContent = msg;
-          document.getElementById("status").appendChild(div);
-          console.log(`[${type.toUpperCase()}] ${msg}`);
-        }
-        function clear() {
-          document.getElementById("status").innerHTML = "";
-        }
-        if (!window.NostrTools) {
-          log("NostrTools not loaded. Check console or ad-blockers.", "error");
+        let initialized = false;
+
+        const reportFailure = (error) => {
+          console.error("[bitvid] Failed to initialize application form", error);
+          const status = document.getElementById("status");
+          if (status) {
+            const div = document.createElement("div");
+            div.classList.add("status-line", "error");
+            div.textContent = "Failed to load Nostr tools. Please disable blockers and try again.";
+            status.appendChild(div);
+          }
+        };
+
+        const start = () => {
+          if (initialized) {
+            return;
+          }
+          if (!window.NostrTools) {
+            reportFailure(new Error("NostrTools not loaded."));
+            return;
+          }
+
+          initialized = true;
+
+          // Logging functions for both on-page and console output.
+          function log(msg, type = "info") {
+            const div = document.createElement("div");
+            div.classList.add("status-line");
+            if (type === "error") div.classList.add("error");
+            if (type === "success") div.classList.add("success");
+            if (type === "warn") div.classList.add("warn");
+            div.textContent = msg;
+            document.getElementById("status").appendChild(div);
+            console.log(`[${type.toUpperCase()}] ${msg}`);
+          }
+          function clear() {
+            document.getElementById("status").innerHTML = "";
+          }
+          const {
+            generateSecretKey,
+            getPublicKey,
+            finalizeEvent,
+            nip04,
+            nip19,
+            SimplePool,
+            Relay,
+          } = window.NostrTools;
+          
+          // Set the recipient's NPUB (your personal NPUB) here.
+          const recipientNpub =
+            "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
+          const RELAYS = [
+            "wss://relay.snort.social",
+            "wss://relay.damus.io",
+            "wss://relay.primal.net",
+          ];
+          const pool = new SimplePool();
+          
+          document
+            .getElementById("wl-form")
+            .addEventListener("submit", async (ev) => {
+              ev.preventDefault();
+              clear();
+              try {
+                // Retrieve applicant-provided input.
+                const applicantNpub = document
+                  .getElementById("applicantNpub")
+                  .value.trim();
+                const contactMethod = document
+                  .getElementById("contactMethod")
+                  .value.trim();
+                const username = document.getElementById("username").value.trim();
+          
+                // Section 2: Content Intent
+                // Get all checked content types
+                const contentTypeNodes = document.querySelectorAll(
+                  'input[name="contentType"]:checked'
+                );
+                let contentTypes = [];
+                contentTypeNodes.forEach((node) => {
+                  contentTypes.push(node.value);
+                });
+                const otherContent = document
+                  .getElementById("otherContent")
+                  .value.trim();
+                const whyJoin = document.getElementById("whyJoin").value.trim();
+                const priorExperience = document
+                  .getElementById("priorExperience")
+                  .value.trim();
+                const experienceLinks = document
+                  .getElementById("experienceLinks")
+                  .value.trim();
+          
+                // Section 3: Community Engagement
+                const familiarGuidelines = document
+                  .getElementById("familiarGuidelines")
+                  .value.trim();
+                const agreeGuidelines = document
+                  .getElementById("agreeGuidelines")
+                  .value.trim();
+                const communityContribution = document
+                  .getElementById("communityContribution")
+                  .value.trim();
+          
+                // Section 4: Additional Information
+                const specialSkills = document
+                  .getElementById("specialSkills")
+                  .value.trim();
+                const testFeatures = document
+                  .getElementById("testFeatures")
+                  .value.trim();
+          
+                // Section 5: Declaration
+                const signature = document
+                  .getElementById("signature")
+                  .value.trim();
+                const declarationDate = document
+                  .getElementById("declarationDate")
+                  .value.trim();
+          
+                // Construct the whitelist application content.
+                const applicationContent = `
+          # **bitvid Whitelist Application Form**
+          
+          **1. Applicant Information**
+          - **Nostr Public Key (npub):** ${applicantNpub}
+          - **Preferred Contact Method:** ${contactMethod || "N/A"}
+          - **Username or Alias:** ${username || "N/A"}
+          
+          **2. Content Intent**
+          - **Planned Content Types:** ${contentTypes.join(", ") || "N/A"}
+          - **Other (if applicable):** ${otherContent || "N/A"}
+          - **Why do you want to join bitvid?**  
+            ${whyJoin || "N/A"}
+          - **Have you created content on other platforms before?** ${
+                  priorExperience || "N/A"
+                }
+          - **Links or references to your previous work:**  
+            ${experienceLinks || "N/A"}
+          
+          **3. Community Engagement**
+          - **Familiar with bitvid’s Community Guidelines?** ${
+                  familiarGuidelines || "N/A"
+                }
+          - **Agree to follow guidelines and respect moderation?** ${
+                  agreeGuidelines || "N/A"
+                }
+          - **How do you plan to contribute to the community?**  
+            ${communityContribution || "N/A"}
+          
+          **4. Additional Information**
+          - **Special skills or interests:**  
+            ${specialSkills || "N/A"}
+          - **Interested in testing new features?** ${testFeatures || "N/A"}
+          
+          **5. Declaration**
+          By submitting this application, you confirm that:
+          - The information provided is accurate.
+          - You understand that approval is based on community alignment and available capacity.
+          - You acknowledge that whitelist status may be revoked if guidelines are violated.
+          
+          **Signature (Digital or Written):** ${signature || "N/A"}
+          **Date:** ${declarationDate || "N/A"}
+          
+          ---
+          
+          **Processing Time:** Applications will be reviewed within **7-14 days**. If approved, you will receive a confirmation via your provided contact method. If additional information is needed, we will reach out.
+          
+          For further questions, contact us through bitvid’s Nostr support channels.
+              `.trim();
+          
+                log(
+                  "[DEBUG] Constructed application content:
+" +
+                    applicationContent
+                );
+          
+                // Decode the recipient NPUB to get the public key.
+                log("Decoding recipient npub...");
+                const decoded = nip19.decode(recipientNpub);
+                log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
+                if (decoded.type !== "npub") {
+                  throw new Error("Decoded type is not npub.");
+                }
+                const targetPubHex = decoded.data;
+                log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
+          
+                // Generate an ephemeral key pair.
+                log("Generating ephemeral key...");
+                const ephemeralPriv = generateSecretKey();
+                const ephemeralPubHex = getPublicKey(ephemeralPriv);
+                log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
+          
+                // Encrypt the application content.
+                log("Encrypting application content (nip04)...");
+                const ciphertext = await nip04.encrypt(
+                  ephemeralPriv,
+                  targetPubHex,
+                  applicationContent
+                );
+                log("[DEBUG] Ciphertext: " + ciphertext);
+                log("Encryption done.");
+          
+                // Build the Nostr event template.
+                const now = Math.floor(Date.now() / 1000);
+                const eventTemplate = {
+                  kind: 4,
+                  created_at: now,
+                  tags: [["p", targetPubHex]],
+                  content: ciphertext,
+                };
+                log(
+                  "[DEBUG] Event template before finalizing: " +
+                    JSON.stringify(eventTemplate)
+                );
+          
+                // Finalize the event (computing the id and signature).
+                const event = finalizeEvent(eventTemplate, ephemeralPriv);
+                log("[DEBUG] Final event: " + JSON.stringify(event));
+          
+                // Publish the event to all relays.
+                log("Publishing the application to relays...");
+                await Promise.any(pool.publish(RELAYS, event));
+                log("At least one relay accepted the event.", "success");
+          
+                // For each relay, subscribe to verify the event appears.
+                for (const url of RELAYS) {
+                  log("Connecting to " + url + " for subscription...");
+                  const relay = await Relay.connect(url);
+                  relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
+                    onEvent(foundEvent) {
+                      if (foundEvent.id === event.id) {
+                        log(
+                          "[" +
+                            url +
+                            "] => Found our application in storage! ID: " +
+                            foundEvent.id.slice(0, 8) +
+                            "...",
+                          "success"
+                        );
+                      }
+                    },
+                    onEose() {
+                      relay.close();
+                    },
+                  });
+                }
+          
+                log(
+                  "Done. If the logs show that at least one relay accepted the event and the application was found in storage, a moderator will review your application within 7-14 days."
+                );
+              } catch (err) {
+                log("Error: " + err.message, "error");
+                console.error(err);
+              }
+            });
+
+        };
+
+        if (window.NostrTools) {
+          start();
           return;
         }
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          nip04,
-          nip19,
-          SimplePool,
-          Relay,
-        } = window.NostrTools;
 
-        // Set the recipient's NPUB (your personal NPUB) here.
-        const recipientNpub =
-          "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
-        const RELAYS = [
-          "wss://relay.snort.social",
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-        ];
-        const pool = new SimplePool();
-
-        document
-          .getElementById("wl-form")
-          .addEventListener("submit", async (ev) => {
-            ev.preventDefault();
-            clear();
-            try {
-              // Retrieve applicant-provided input.
-              const applicantNpub = document
-                .getElementById("applicantNpub")
-                .value.trim();
-              const contactMethod = document
-                .getElementById("contactMethod")
-                .value.trim();
-              const username = document.getElementById("username").value.trim();
-
-              // Section 2: Content Intent
-              // Get all checked content types
-              const contentTypeNodes = document.querySelectorAll(
-                'input[name="contentType"]:checked'
-              );
-              let contentTypes = [];
-              contentTypeNodes.forEach((node) => {
-                contentTypes.push(node.value);
-              });
-              const otherContent = document
-                .getElementById("otherContent")
-                .value.trim();
-              const whyJoin = document.getElementById("whyJoin").value.trim();
-              const priorExperience = document
-                .getElementById("priorExperience")
-                .value.trim();
-              const experienceLinks = document
-                .getElementById("experienceLinks")
-                .value.trim();
-
-              // Section 3: Community Engagement
-              const familiarGuidelines = document
-                .getElementById("familiarGuidelines")
-                .value.trim();
-              const agreeGuidelines = document
-                .getElementById("agreeGuidelines")
-                .value.trim();
-              const communityContribution = document
-                .getElementById("communityContribution")
-                .value.trim();
-
-              // Section 4: Additional Information
-              const specialSkills = document
-                .getElementById("specialSkills")
-                .value.trim();
-              const testFeatures = document
-                .getElementById("testFeatures")
-                .value.trim();
-
-              // Section 5: Declaration
-              const signature = document
-                .getElementById("signature")
-                .value.trim();
-              const declarationDate = document
-                .getElementById("declarationDate")
-                .value.trim();
-
-              // Construct the whitelist application content.
-              const applicationContent = `
-# **bitvid Whitelist Application Form**
-
-**1. Applicant Information**
-- **Nostr Public Key (npub):** ${applicantNpub}
-- **Preferred Contact Method:** ${contactMethod || "N/A"}
-- **Username or Alias:** ${username || "N/A"}
-
-**2. Content Intent**
-- **Planned Content Types:** ${contentTypes.join(", ") || "N/A"}
-- **Other (if applicable):** ${otherContent || "N/A"}
-- **Why do you want to join bitvid?**  
-  ${whyJoin || "N/A"}
-- **Have you created content on other platforms before?** ${
-                priorExperience || "N/A"
-              }
-- **Links or references to your previous work:**  
-  ${experienceLinks || "N/A"}
-
-**3. Community Engagement**
-- **Familiar with bitvid’s Community Guidelines?** ${
-                familiarGuidelines || "N/A"
-              }
-- **Agree to follow guidelines and respect moderation?** ${
-                agreeGuidelines || "N/A"
-              }
-- **How do you plan to contribute to the community?**  
-  ${communityContribution || "N/A"}
-
-**4. Additional Information**
-- **Special skills or interests:**  
-  ${specialSkills || "N/A"}
-- **Interested in testing new features?** ${testFeatures || "N/A"}
-
-**5. Declaration**
-By submitting this application, you confirm that:
-- The information provided is accurate.
-- You understand that approval is based on community alignment and available capacity.
-- You acknowledge that whitelist status may be revoked if guidelines are violated.
-
-**Signature (Digital or Written):** ${signature || "N/A"}
-**Date:** ${declarationDate || "N/A"}
-
----
-
-**Processing Time:** Applications will be reviewed within **7-14 days**. If approved, you will receive a confirmation via your provided contact method. If additional information is needed, we will reach out.
-
-For further questions, contact us through bitvid’s Nostr support channels.
-            `.trim();
-
-              log(
-                "[DEBUG] Constructed application content:\n" +
-                  applicationContent
-              );
-
-              // Decode the recipient NPUB to get the public key.
-              log("Decoding recipient npub...");
-              const decoded = nip19.decode(recipientNpub);
-              log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
-              if (decoded.type !== "npub") {
-                throw new Error("Decoded type is not npub.");
-              }
-              const targetPubHex = decoded.data;
-              log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
-
-              // Generate an ephemeral key pair.
-              log("Generating ephemeral key...");
-              const ephemeralPriv = generateSecretKey();
-              const ephemeralPubHex = getPublicKey(ephemeralPriv);
-              log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
-
-              // Encrypt the application content.
-              log("Encrypting application content (nip04)...");
-              const ciphertext = await nip04.encrypt(
-                ephemeralPriv,
-                targetPubHex,
-                applicationContent
-              );
-              log("[DEBUG] Ciphertext: " + ciphertext);
-              log("Encryption done.");
-
-              // Build the Nostr event template.
-              const now = Math.floor(Date.now() / 1000);
-              const eventTemplate = {
-                kind: 4,
-                created_at: now,
-                tags: [["p", targetPubHex]],
-                content: ciphertext,
-              };
-              log(
-                "[DEBUG] Event template before finalizing: " +
-                  JSON.stringify(eventTemplate)
-              );
-
-              // Finalize the event (computing the id and signature).
-              const event = finalizeEvent(eventTemplate, ephemeralPriv);
-              log("[DEBUG] Final event: " + JSON.stringify(event));
-
-              // Publish the event to all relays.
-              log("Publishing the application to relays...");
-              await Promise.any(pool.publish(RELAYS, event));
-              log("At least one relay accepted the event.", "success");
-
-              // For each relay, subscribe to verify the event appears.
-              for (const url of RELAYS) {
-                log("Connecting to " + url + " for subscription...");
-                const relay = await Relay.connect(url);
-                relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
-                  onEvent(foundEvent) {
-                    if (foundEvent.id === event.id) {
-                      log(
-                        "[" +
-                          url +
-                          "] => Found our application in storage! ID: " +
-                          foundEvent.id.slice(0, 8) +
-                          "...",
-                        "success"
-                      );
-                    }
-                  },
-                  onEose() {
-                    relay.close();
-                  },
-                });
-              }
-
-              log(
-                "Done. If the logs show that at least one relay accepted the event and the application was found in storage, a moderator will review your application within 7-14 days."
-              );
-            } catch (err) {
-              log("Error: " + err.message, "error");
-              console.error(err);
-            }
-          });
+        const ready = window.NostrToolsReady;
+        if (ready && typeof ready.then === "function") {
+          ready.then(() => start()).catch(reportFailure);
+        } else {
+          window.addEventListener(
+            "bitvid:nostr-tools-ready",
+            () => start(),
+            { once: true }
+          );
+        }
       });
     </script>
   </body>

--- a/components/iframe_forms/iframe-bug-fix-form.html
+++ b/components/iframe_forms/iframe-bug-fix-form.html
@@ -127,8 +127,36 @@
         scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
       }
     </style>
-    <!-- Load nostr‑tools v2.10.4 -->
-    <script src="https://cdn.jsdelivr.net/npm/nostr-tools@2.10.4/lib/nostr.bundle.min.js"></script>
+    <!-- Load nostr‑tools v2.10.4 and expose nip04 for legacy consumers -->
+    <script type="module">
+      const NOSTR_TOOLS_VERSION = "2.10.4";
+
+      const loadNostrTools = async () => {
+        const nostrModule = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`);
+        const { nip04 } = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`);
+
+        const toolsBundle = {
+          ...nostrModule,
+          nip04,
+        };
+
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
+
+        return toolsBundle;
+      };
+
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
+
+      window.NostrToolsReady = nostrToolsPromise;
+    </script>
   </head>
   <body>
     <div class="container">
@@ -292,239 +320,278 @@
     </div>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        // Logging functions for both on-page and console output.
-        function log(msg, type = "info") {
-          const div = document.createElement("div");
-          div.classList.add("status-line");
-          if (type === "error") div.classList.add("error");
-          if (type === "success") div.classList.add("success");
-          if (type === "warn") div.classList.add("warn");
-          div.textContent = msg;
-          document.getElementById("status").appendChild(div);
-          console.log(`[${type.toUpperCase()}] ${msg}`);
-        }
-        function clear() {
-          document.getElementById("status").innerHTML = "";
-        }
-        if (!window.NostrTools) {
-          log("NostrTools not loaded. Check console or ad-blockers.", "error");
+        let initialized = false;
+
+        const reportFailure = (error) => {
+          console.error("[bitvid] Failed to initialize bug report form", error);
+          const status = document.getElementById("status");
+          if (status) {
+            const div = document.createElement("div");
+            div.classList.add("status-line", "error");
+            div.textContent = "Failed to load Nostr tools. Please disable blockers and try again.";
+            status.appendChild(div);
+          }
+        };
+
+        const start = () => {
+          if (initialized) {
+            return;
+          }
+          if (!window.NostrTools) {
+            reportFailure(new Error("NostrTools not loaded."));
+            return;
+          }
+
+          initialized = true;
+
+          // Logging functions for both on-page and console output.
+          function log(msg, type = "info") {
+            const div = document.createElement("div");
+            div.classList.add("status-line");
+            if (type === "error") div.classList.add("error");
+            if (type === "success") div.classList.add("success");
+            if (type === "warn") div.classList.add("warn");
+            div.textContent = msg;
+            document.getElementById("status").appendChild(div);
+            console.log(`[${type.toUpperCase()}] ${msg}`);
+          }
+          function clear() {
+            document.getElementById("status").innerHTML = "";
+          }
+          const {
+            generateSecretKey,
+            getPublicKey,
+            finalizeEvent,
+            nip04,
+            nip19,
+            SimplePool,
+            Relay,
+          } = window.NostrTools;
+          
+          // Set the recipient's NPUB (your personal NPUB)
+          const recipientNpub =
+            "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
+          const RELAYS = [
+            "wss://relay.snort.social",
+            "wss://relay.damus.io",
+            "wss://relay.primal.net",
+          ];
+          const pool = new SimplePool();
+          
+          document
+            .getElementById("bug-form")
+            .addEventListener("submit", async (ev) => {
+              ev.preventDefault();
+              clear();
+              try {
+                // Section 1: User Information
+                const userNpub = document.getElementById("userNpub").value.trim();
+                const roleNodes = document.querySelectorAll(
+                  'input[name="userRole"]:checked'
+                );
+                let userRoles = [];
+                roleNodes.forEach((node) => {
+                  userRoles.push(node.value);
+                });
+          
+                // Section 2: Bug Details
+                const issueDescription = document
+                  .getElementById("issueDescription")
+                  .value.trim();
+                const stepsToReproduce = document
+                  .getElementById("stepsToReproduce")
+                  .value.trim();
+                const expectedBehavior = document
+                  .getElementById("expectedBehavior")
+                  .value.trim();
+                const actualBehavior = document
+                  .getElementById("actualBehavior")
+                  .value.trim();
+          
+                // Section 3: Device & Environment
+                const deviceNodes = document.querySelectorAll(
+                  'input[name="deviceUsed"]:checked'
+                );
+                let devicesUsed = [];
+                deviceNodes.forEach((node) => {
+                  devicesUsed.push(node.value);
+                });
+                const operatingSystem = document
+                  .getElementById("operatingSystem")
+                  .value.trim();
+                const browserInfo = document
+                  .getElementById("browserInfo")
+                  .value.trim();
+                const usingVPN = document.getElementById("usingVPN").value.trim();
+          
+                // Section 4: Screenshots or Logs
+                const screenshotInfo = document
+                  .getElementById("screenshotInfo")
+                  .value.trim();
+                const errorMessages = document
+                  .getElementById("errorMessages")
+                  .value.trim();
+                const consoleLogs = document
+                  .getElementById("consoleLogs")
+                  .value.trim();
+          
+                // Section 5: Additional Information
+                const bugFrequency = document
+                  .getElementById("bugFrequency")
+                  .value.trim();
+                const impactCore = document
+                  .getElementById("impactCore")
+                  .value.trim();
+                const additionalNotes = document
+                  .getElementById("additionalNotes")
+                  .value.trim();
+          
+                // Construct the bug report content as Markdown.
+                const bugReportContent = `
+          # **bitvid Bug Report Form**
+          
+          If you have encountered a bug or technical issue on bitvid, please fill out this form to help us diagnose and resolve the problem. Providing detailed information will assist us in troubleshooting more efficiently.
+          
+          ## **1. User Information**
+          - **Nostr Public Key (npub) (optional):** ${userNpub || "N/A"}
+          - **Roles:** ${userRoles.length > 0 ? userRoles.join(", ") : "N/A"}
+          
+          ## **2. Bug Details**
+          - **Describe the issue:**  
+            ${issueDescription || "N/A"}
+          - **Steps to reproduce the bug:**  
+            ${stepsToReproduce || "N/A"}
+          - **Expected behavior:**  
+            ${expectedBehavior || "N/A"}
+          - **Actual behavior:**  
+            ${actualBehavior || "N/A"}
+          
+          ## **3. Device & Environment**
+          - **Devices used:** ${devicesUsed.length > 0 ? devicesUsed.join(", ") : "N/A"}
+          - **Operating System:** ${operatingSystem || "N/A"}
+          - **Browser:** ${browserInfo || "N/A"}
+          - **Using VPN/Privacy Settings:** ${usingVPN || "N/A"}
+          
+          ## **4. Screenshots or Logs**
+          - **Screenshot/Recording:** ${screenshotInfo || "N/A"}
+          - **Error Messages:** ${errorMessages || "N/A"}
+          - **Console Logs:** ${consoleLogs || "N/A"}
+          
+          ## **5. Additional Information**
+          - **Bug Frequency:** ${bugFrequency || "N/A"}
+          - **Impact on Core Functionality:** ${impactCore || "N/A"}
+          - **Additional Notes:** ${additionalNotes || "N/A"}
+          
+          ---
+          
+          **Processing & Resolution:**  
+          Our team reviews bug reports regularly. While we aim to fix critical issues as soon as possible, some bugs may take longer to resolve. We appreciate your patience and help in improving bitvid!
+          
+          For urgent issues, contact us through bitvid’s Nostr support channels.
+              `.trim();
+          
+                log(
+                  "[DEBUG] Constructed bug report content:
+" + bugReportContent
+                );
+          
+                // Decode the recipient NPUB to get the public key.
+                log("Decoding recipient npub...");
+                const decoded = nip19.decode(recipientNpub);
+                log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
+                if (decoded.type !== "npub") {
+                  throw new Error("Decoded type is not npub.");
+                }
+                const targetPubHex = decoded.data;
+                log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
+          
+                // Generate an ephemeral key pair.
+                log("Generating ephemeral key...");
+                const ephemeralPriv = generateSecretKey();
+                const ephemeralPubHex = getPublicKey(ephemeralPriv);
+                log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
+          
+                // Encrypt the bug report content.
+                log("Encrypting bug report content (nip04)...");
+                const ciphertext = await nip04.encrypt(
+                  ephemeralPriv,
+                  targetPubHex,
+                  bugReportContent
+                );
+                log("[DEBUG] Ciphertext: " + ciphertext);
+                log("Encryption done.");
+          
+                // Build the event template.
+                const now = Math.floor(Date.now() / 1000);
+                const eventTemplate = {
+                  kind: 4,
+                  created_at: now,
+                  tags: [["p", targetPubHex]],
+                  content: ciphertext,
+                };
+                log(
+                  "[DEBUG] Event template before finalizing: " +
+                    JSON.stringify(eventTemplate)
+                );
+          
+                // Finalize the event.
+                const event = finalizeEvent(eventTemplate, ephemeralPriv);
+                log("[DEBUG] Final event: " + JSON.stringify(event));
+          
+                // Publish the event to all relays.
+                log("Publishing the bug report to relays...");
+                await Promise.any(pool.publish(RELAYS, event));
+                log("At least one relay accepted the event.", "success");
+          
+                // Subscribe to each relay.
+                for (const url of RELAYS) {
+                  log("Connecting to " + url + " for subscription...");
+                  const relay = await Relay.connect(url);
+                  relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
+                    onEvent(foundEvent) {
+                      if (foundEvent.id === event.id) {
+                        log(
+                          "[" +
+                            url +
+                            "] => Found our bug report in storage! ID: " +
+                            foundEvent.id.slice(0, 8) +
+                            "...",
+                          "success"
+                        );
+                      }
+                    },
+                    onEose() {
+                      relay.close();
+                    },
+                  });
+                }
+          
+                log(
+                  "Done. If the logs show that at least one relay accepted the event and the bug report was found in storage, our team will review your report within 7-14 days."
+                );
+              } catch (err) {
+                log("Error: " + err.message, "error");
+                console.error(err);
+              }
+            });
+
+        };
+
+        if (window.NostrTools) {
+          start();
           return;
         }
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          nip04,
-          nip19,
-          SimplePool,
-          Relay,
-        } = window.NostrTools;
 
-        // Set the recipient's NPUB (your personal NPUB)
-        const recipientNpub =
-          "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
-        const RELAYS = [
-          "wss://relay.snort.social",
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-        ];
-        const pool = new SimplePool();
-
-        document
-          .getElementById("bug-form")
-          .addEventListener("submit", async (ev) => {
-            ev.preventDefault();
-            clear();
-            try {
-              // Section 1: User Information
-              const userNpub = document.getElementById("userNpub").value.trim();
-              const roleNodes = document.querySelectorAll(
-                'input[name="userRole"]:checked'
-              );
-              let userRoles = [];
-              roleNodes.forEach((node) => {
-                userRoles.push(node.value);
-              });
-
-              // Section 2: Bug Details
-              const issueDescription = document
-                .getElementById("issueDescription")
-                .value.trim();
-              const stepsToReproduce = document
-                .getElementById("stepsToReproduce")
-                .value.trim();
-              const expectedBehavior = document
-                .getElementById("expectedBehavior")
-                .value.trim();
-              const actualBehavior = document
-                .getElementById("actualBehavior")
-                .value.trim();
-
-              // Section 3: Device & Environment
-              const deviceNodes = document.querySelectorAll(
-                'input[name="deviceUsed"]:checked'
-              );
-              let devicesUsed = [];
-              deviceNodes.forEach((node) => {
-                devicesUsed.push(node.value);
-              });
-              const operatingSystem = document
-                .getElementById("operatingSystem")
-                .value.trim();
-              const browserInfo = document
-                .getElementById("browserInfo")
-                .value.trim();
-              const usingVPN = document.getElementById("usingVPN").value.trim();
-
-              // Section 4: Screenshots or Logs
-              const screenshotInfo = document
-                .getElementById("screenshotInfo")
-                .value.trim();
-              const errorMessages = document
-                .getElementById("errorMessages")
-                .value.trim();
-              const consoleLogs = document
-                .getElementById("consoleLogs")
-                .value.trim();
-
-              // Section 5: Additional Information
-              const bugFrequency = document
-                .getElementById("bugFrequency")
-                .value.trim();
-              const impactCore = document
-                .getElementById("impactCore")
-                .value.trim();
-              const additionalNotes = document
-                .getElementById("additionalNotes")
-                .value.trim();
-
-              // Construct the bug report content as Markdown.
-              const bugReportContent = `
-# **bitvid Bug Report Form**
-
-If you have encountered a bug or technical issue on bitvid, please fill out this form to help us diagnose and resolve the problem. Providing detailed information will assist us in troubleshooting more efficiently.
-
-## **1. User Information**
-- **Nostr Public Key (npub) (optional):** ${userNpub || "N/A"}
-- **Roles:** ${userRoles.length > 0 ? userRoles.join(", ") : "N/A"}
-
-## **2. Bug Details**
-- **Describe the issue:**  
-  ${issueDescription || "N/A"}
-- **Steps to reproduce the bug:**  
-  ${stepsToReproduce || "N/A"}
-- **Expected behavior:**  
-  ${expectedBehavior || "N/A"}
-- **Actual behavior:**  
-  ${actualBehavior || "N/A"}
-
-## **3. Device & Environment**
-- **Devices used:** ${devicesUsed.length > 0 ? devicesUsed.join(", ") : "N/A"}
-- **Operating System:** ${operatingSystem || "N/A"}
-- **Browser:** ${browserInfo || "N/A"}
-- **Using VPN/Privacy Settings:** ${usingVPN || "N/A"}
-
-## **4. Screenshots or Logs**
-- **Screenshot/Recording:** ${screenshotInfo || "N/A"}
-- **Error Messages:** ${errorMessages || "N/A"}
-- **Console Logs:** ${consoleLogs || "N/A"}
-
-## **5. Additional Information**
-- **Bug Frequency:** ${bugFrequency || "N/A"}
-- **Impact on Core Functionality:** ${impactCore || "N/A"}
-- **Additional Notes:** ${additionalNotes || "N/A"}
-
----
-
-**Processing & Resolution:**  
-Our team reviews bug reports regularly. While we aim to fix critical issues as soon as possible, some bugs may take longer to resolve. We appreciate your patience and help in improving bitvid!
-
-For urgent issues, contact us through bitvid’s Nostr support channels.
-            `.trim();
-
-              log(
-                "[DEBUG] Constructed bug report content:\n" + bugReportContent
-              );
-
-              // Decode the recipient NPUB to get the public key.
-              log("Decoding recipient npub...");
-              const decoded = nip19.decode(recipientNpub);
-              log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
-              if (decoded.type !== "npub") {
-                throw new Error("Decoded type is not npub.");
-              }
-              const targetPubHex = decoded.data;
-              log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
-
-              // Generate an ephemeral key pair.
-              log("Generating ephemeral key...");
-              const ephemeralPriv = generateSecretKey();
-              const ephemeralPubHex = getPublicKey(ephemeralPriv);
-              log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
-
-              // Encrypt the bug report content.
-              log("Encrypting bug report content (nip04)...");
-              const ciphertext = await nip04.encrypt(
-                ephemeralPriv,
-                targetPubHex,
-                bugReportContent
-              );
-              log("[DEBUG] Ciphertext: " + ciphertext);
-              log("Encryption done.");
-
-              // Build the event template.
-              const now = Math.floor(Date.now() / 1000);
-              const eventTemplate = {
-                kind: 4,
-                created_at: now,
-                tags: [["p", targetPubHex]],
-                content: ciphertext,
-              };
-              log(
-                "[DEBUG] Event template before finalizing: " +
-                  JSON.stringify(eventTemplate)
-              );
-
-              // Finalize the event.
-              const event = finalizeEvent(eventTemplate, ephemeralPriv);
-              log("[DEBUG] Final event: " + JSON.stringify(event));
-
-              // Publish the event to all relays.
-              log("Publishing the bug report to relays...");
-              await Promise.any(pool.publish(RELAYS, event));
-              log("At least one relay accepted the event.", "success");
-
-              // Subscribe to each relay.
-              for (const url of RELAYS) {
-                log("Connecting to " + url + " for subscription...");
-                const relay = await Relay.connect(url);
-                relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
-                  onEvent(foundEvent) {
-                    if (foundEvent.id === event.id) {
-                      log(
-                        "[" +
-                          url +
-                          "] => Found our bug report in storage! ID: " +
-                          foundEvent.id.slice(0, 8) +
-                          "...",
-                        "success"
-                      );
-                    }
-                  },
-                  onEose() {
-                    relay.close();
-                  },
-                });
-              }
-
-              log(
-                "Done. If the logs show that at least one relay accepted the event and the bug report was found in storage, our team will review your report within 7-14 days."
-              );
-            } catch (err) {
-              log("Error: " + err.message, "error");
-              console.error(err);
-            }
-          });
+        const ready = window.NostrToolsReady;
+        if (ready && typeof ready.then === "function") {
+          ready.then(() => start()).catch(reportFailure);
+        } else {
+          window.addEventListener(
+            "bitvid:nostr-tools-ready",
+            () => start(),
+            { once: true }
+          );
+        }
       });
     </script>
   </body>

--- a/components/iframe_forms/iframe-content-appeals-form.html
+++ b/components/iframe_forms/iframe-content-appeals-form.html
@@ -120,8 +120,36 @@
         scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
       }
     </style>
-    <!-- Load nostr‑tools v2.10.4 -->
-    <script src="https://cdn.jsdelivr.net/npm/nostr-tools@2.10.4/lib/nostr.bundle.min.js"></script>
+    <!-- Load nostr‑tools v2.10.4 and expose nip04 for legacy consumers -->
+    <script type="module">
+      const NOSTR_TOOLS_VERSION = "2.10.4";
+
+      const loadNostrTools = async () => {
+        const nostrModule = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`);
+        const { nip04 } = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`);
+
+        const toolsBundle = {
+          ...nostrModule,
+          nip04,
+        };
+
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
+
+        return toolsBundle;
+      };
+
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
+
+      window.NostrToolsReady = nostrToolsPromise;
+    </script>
   </head>
   <body>
     <div class="container">
@@ -243,221 +271,260 @@
     </div>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        // Logging functions for both on-page and console output.
-        function log(msg, type = "info") {
-          const div = document.createElement("div");
-          div.classList.add("status-line");
-          if (type === "error") div.classList.add("error");
-          if (type === "success") div.classList.add("success");
-          if (type === "warn") div.classList.add("warn");
-          div.textContent = msg;
-          document.getElementById("status").appendChild(div);
-          console.log(`[${type.toUpperCase()}] ${msg}`);
-        }
-        function clear() {
-          document.getElementById("status").innerHTML = "";
-        }
-        if (!window.NostrTools) {
-          log("NostrTools not loaded. Check console or ad-blockers.", "error");
+        let initialized = false;
+
+        const reportFailure = (error) => {
+          console.error("[bitvid] Failed to initialize content appeals form", error);
+          const status = document.getElementById("status");
+          if (status) {
+            const div = document.createElement("div");
+            div.classList.add("status-line", "error");
+            div.textContent = "Failed to load Nostr tools. Please disable blockers and try again.";
+            status.appendChild(div);
+          }
+        };
+
+        const start = () => {
+          if (initialized) {
+            return;
+          }
+          if (!window.NostrTools) {
+            reportFailure(new Error("NostrTools not loaded."));
+            return;
+          }
+
+          initialized = true;
+
+          // Logging functions for both on-page and console output.
+          function log(msg, type = "info") {
+            const div = document.createElement("div");
+            div.classList.add("status-line");
+            if (type === "error") div.classList.add("error");
+            if (type === "success") div.classList.add("success");
+            if (type === "warn") div.classList.add("warn");
+            div.textContent = msg;
+            document.getElementById("status").appendChild(div);
+            console.log(`[${type.toUpperCase()}] ${msg}`);
+          }
+          function clear() {
+            document.getElementById("status").innerHTML = "";
+          }
+          const {
+            generateSecretKey,
+            getPublicKey,
+            finalizeEvent,
+            nip04,
+            nip19,
+            SimplePool,
+            Relay,
+          } = window.NostrTools;
+          
+          // Set the recipient's NPUB (your personal NPUB) here.
+          const recipientNpub =
+            "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
+          
+          const RELAYS = [
+            "wss://relay.snort.social",
+            "wss://relay.damus.io",
+            "wss://relay.primal.net",
+          ];
+          const pool = new SimplePool();
+          
+          document
+            .getElementById("dm-form")
+            .addEventListener("submit", async (ev) => {
+              ev.preventDefault();
+              clear();
+              try {
+                // Note: The customer's NPUB input is removed.
+                // Use the recipientNpub constant to get the public key.
+          
+                const contactMethod = document
+                  .getElementById("contactMethod")
+                  .value.trim();
+                const videoTitle = document
+                  .getElementById("videoTitle")
+                  .value.trim();
+                const magnetLink = document
+                  .getElementById("magnetLink")
+                  .value.trim();
+                const submissionDate = document
+                  .getElementById("submissionDate")
+                  .value.trim();
+                const reasonBlocked = document
+                  .getElementById("reasonBlocked")
+                  .value.trim();
+                const fitsGuidelines = document
+                  .getElementById("fitsGuidelines")
+                  .value.trim();
+                const guidelinesCited = document
+                  .getElementById("guidelinesCited")
+                  .value.trim();
+                const editedContent = document
+                  .getElementById("editedContent")
+                  .value.trim();
+                const changesMade = document
+                  .getElementById("changesMade")
+                  .value.trim();
+                const misunderstanding = document
+                  .getElementById("misunderstanding")
+                  .value.trim();
+                const externalReferences = document
+                  .getElementById("externalReferences")
+                  .value.trim();
+                const signature = document
+                  .getElementById("signature")
+                  .value.trim();
+                const declarationDate = document
+                  .getElementById("declarationDate")
+                  .value.trim();
+          
+                // Construct the appeal content.
+                const appealContent = `
+          # **bitvid Content Appeals Form**
+            
+          **1. User Information**
+          - **Contact Method:** ${contactMethod || "N/A"}
+            
+          **2. Content Details**
+          - **Title of the Video:** ${videoTitle}
+          - **Magnet Link:** ${magnetLink}
+          - **Date of Content Submission:** ${submissionDate}
+            
+          **3. Reason for Appeal**
+          - **Why do you believe your content was unfairly blocked?**  
+            ${reasonBlocked}
+          - **Does your content fit within bitvid's Community Guidelines?**  
+            ${fitsGuidelines}
+          - **If yes, which guideline(s) support your appeal?**  
+            ${guidelinesCited}
+          - **Was this content edited after being blocked?**  
+            ${editedContent}
+          - **If yes, what changes were made?**  
+            ${changesMade}
+            
+          **4. Additional Context**
+          - **Was there any misunderstanding or misclassification?**  
+            ${misunderstanding}
+          - **Are there external references that validate your appeal?**  
+            ${externalReferences}
+            
+          **5. Declaration**
+          By submitting this appeal, you confirm that:
+          - You are the original creator or an authorized representative of the content.
+          - Your appeal is submitted in good faith and aligns with bitvid’s policies.
+          - You understand that final decisions are at the discretion of bitvid’s moderation process.
+            
+          **Signature (Digital or Written):** ${signature}
+          **Date:** ${declarationDate}
+            
+          ---
+            
+          **Processing Time:** Appeals will be reviewed within **7-14 days**. If additional information is required, you will be contacted via your provided contact method.
+            
+          For further questions, reach out through bitvid’s Nostr support channels.
+              `.trim();
+          
+                log("[DEBUG] Constructed appeal content:
+" + appealContent);
+          
+                // Decode the recipient NPUB to get the public key.
+                log("Decoding recipient npub...");
+                const decoded = nip19.decode(recipientNpub);
+                log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
+                if (decoded.type !== "npub") {
+                  throw new Error("Decoded type is not npub.");
+                }
+                const targetPubHex = decoded.data;
+                log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
+          
+                // Generate an ephemeral key pair.
+                log("Generating ephemeral key...");
+                const ephemeralPriv = generateSecretKey();
+                const ephemeralPubHex = getPublicKey(ephemeralPriv);
+                log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
+          
+                // Encrypt the appeal content.
+                log("Encrypting appeal content (nip04)...");
+                const ciphertext = await nip04.encrypt(
+                  ephemeralPriv,
+                  targetPubHex,
+                  appealContent
+                );
+                log("[DEBUG] Ciphertext: " + ciphertext);
+                log("Encryption done.");
+          
+                // Build the event template.
+                const now = Math.floor(Date.now() / 1000);
+                const eventTemplate = {
+                  kind: 4,
+                  created_at: now,
+                  tags: [["p", targetPubHex]],
+                  content: ciphertext,
+                };
+                log(
+                  "[DEBUG] Event template before finalizing: " +
+                    JSON.stringify(eventTemplate)
+                );
+          
+                // Finalize the event.
+                const event = finalizeEvent(eventTemplate, ephemeralPriv);
+                log("[DEBUG] Final event: " + JSON.stringify(event));
+          
+                // Publish the event to all relays.
+                log("Publishing the appeal to relays...");
+                await Promise.any(pool.publish(RELAYS, event));
+                log("At least one relay accepted the event.", "success");
+          
+                // Subscribe to each relay.
+                for (const url of RELAYS) {
+                  log("Connecting to " + url + " for subscription...");
+                  const relay = await Relay.connect(url);
+                  relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
+                    onEvent(foundEvent) {
+                      if (foundEvent.id === event.id) {
+                        log(
+                          "[" +
+                            url +
+                            "] => Found our appeal in storage! ID: " +
+                            foundEvent.id.slice(0, 8) +
+                            "...",
+                          "success"
+                        );
+                      }
+                    },
+                    onEose() {
+                      relay.close();
+                    },
+                  });
+                }
+          
+                log(
+                  "Done. If the logs show that at least one relay accepted the event and the appeal was found in storage, a moderator will review your appeal within 7-14 days."
+                );
+              } catch (err) {
+                log("Error: " + err.message, "error");
+                console.error(err);
+              }
+            });
+
+        };
+
+        if (window.NostrTools) {
+          start();
           return;
         }
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          nip04,
-          nip19,
-          SimplePool,
-          Relay,
-        } = window.NostrTools;
 
-        // Set the recipient's NPUB (your personal NPUB) here.
-        const recipientNpub =
-          "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
-
-        const RELAYS = [
-          "wss://relay.snort.social",
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-        ];
-        const pool = new SimplePool();
-
-        document
-          .getElementById("dm-form")
-          .addEventListener("submit", async (ev) => {
-            ev.preventDefault();
-            clear();
-            try {
-              // Note: The customer's NPUB input is removed.
-              // Use the recipientNpub constant to get the public key.
-
-              const contactMethod = document
-                .getElementById("contactMethod")
-                .value.trim();
-              const videoTitle = document
-                .getElementById("videoTitle")
-                .value.trim();
-              const magnetLink = document
-                .getElementById("magnetLink")
-                .value.trim();
-              const submissionDate = document
-                .getElementById("submissionDate")
-                .value.trim();
-              const reasonBlocked = document
-                .getElementById("reasonBlocked")
-                .value.trim();
-              const fitsGuidelines = document
-                .getElementById("fitsGuidelines")
-                .value.trim();
-              const guidelinesCited = document
-                .getElementById("guidelinesCited")
-                .value.trim();
-              const editedContent = document
-                .getElementById("editedContent")
-                .value.trim();
-              const changesMade = document
-                .getElementById("changesMade")
-                .value.trim();
-              const misunderstanding = document
-                .getElementById("misunderstanding")
-                .value.trim();
-              const externalReferences = document
-                .getElementById("externalReferences")
-                .value.trim();
-              const signature = document
-                .getElementById("signature")
-                .value.trim();
-              const declarationDate = document
-                .getElementById("declarationDate")
-                .value.trim();
-
-              // Construct the appeal content.
-              const appealContent = `
-# **bitvid Content Appeals Form**
-  
-**1. User Information**
-- **Contact Method:** ${contactMethod || "N/A"}
-  
-**2. Content Details**
-- **Title of the Video:** ${videoTitle}
-- **Magnet Link:** ${magnetLink}
-- **Date of Content Submission:** ${submissionDate}
-  
-**3. Reason for Appeal**
-- **Why do you believe your content was unfairly blocked?**  
-  ${reasonBlocked}
-- **Does your content fit within bitvid's Community Guidelines?**  
-  ${fitsGuidelines}
-- **If yes, which guideline(s) support your appeal?**  
-  ${guidelinesCited}
-- **Was this content edited after being blocked?**  
-  ${editedContent}
-- **If yes, what changes were made?**  
-  ${changesMade}
-  
-**4. Additional Context**
-- **Was there any misunderstanding or misclassification?**  
-  ${misunderstanding}
-- **Are there external references that validate your appeal?**  
-  ${externalReferences}
-  
-**5. Declaration**
-By submitting this appeal, you confirm that:
-- You are the original creator or an authorized representative of the content.
-- Your appeal is submitted in good faith and aligns with bitvid’s policies.
-- You understand that final decisions are at the discretion of bitvid’s moderation process.
-  
-**Signature (Digital or Written):** ${signature}
-**Date:** ${declarationDate}
-  
----
-  
-**Processing Time:** Appeals will be reviewed within **7-14 days**. If additional information is required, you will be contacted via your provided contact method.
-  
-For further questions, reach out through bitvid’s Nostr support channels.
-            `.trim();
-
-              log("[DEBUG] Constructed appeal content:\n" + appealContent);
-
-              // Decode the recipient NPUB to get the public key.
-              log("Decoding recipient npub...");
-              const decoded = nip19.decode(recipientNpub);
-              log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
-              if (decoded.type !== "npub") {
-                throw new Error("Decoded type is not npub.");
-              }
-              const targetPubHex = decoded.data;
-              log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
-
-              // Generate an ephemeral key pair.
-              log("Generating ephemeral key...");
-              const ephemeralPriv = generateSecretKey();
-              const ephemeralPubHex = getPublicKey(ephemeralPriv);
-              log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
-
-              // Encrypt the appeal content.
-              log("Encrypting appeal content (nip04)...");
-              const ciphertext = await nip04.encrypt(
-                ephemeralPriv,
-                targetPubHex,
-                appealContent
-              );
-              log("[DEBUG] Ciphertext: " + ciphertext);
-              log("Encryption done.");
-
-              // Build the event template.
-              const now = Math.floor(Date.now() / 1000);
-              const eventTemplate = {
-                kind: 4,
-                created_at: now,
-                tags: [["p", targetPubHex]],
-                content: ciphertext,
-              };
-              log(
-                "[DEBUG] Event template before finalizing: " +
-                  JSON.stringify(eventTemplate)
-              );
-
-              // Finalize the event.
-              const event = finalizeEvent(eventTemplate, ephemeralPriv);
-              log("[DEBUG] Final event: " + JSON.stringify(event));
-
-              // Publish the event to all relays.
-              log("Publishing the appeal to relays...");
-              await Promise.any(pool.publish(RELAYS, event));
-              log("At least one relay accepted the event.", "success");
-
-              // Subscribe to each relay.
-              for (const url of RELAYS) {
-                log("Connecting to " + url + " for subscription...");
-                const relay = await Relay.connect(url);
-                relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
-                  onEvent(foundEvent) {
-                    if (foundEvent.id === event.id) {
-                      log(
-                        "[" +
-                          url +
-                          "] => Found our appeal in storage! ID: " +
-                          foundEvent.id.slice(0, 8) +
-                          "...",
-                        "success"
-                      );
-                    }
-                  },
-                  onEose() {
-                    relay.close();
-                  },
-                });
-              }
-
-              log(
-                "Done. If the logs show that at least one relay accepted the event and the appeal was found in storage, a moderator will review your appeal within 7-14 days."
-              );
-            } catch (err) {
-              log("Error: " + err.message, "error");
-              console.error(err);
-            }
-          });
+        const ready = window.NostrToolsReady;
+        if (ready && typeof ready.then === "function") {
+          ready.then(() => start()).catch(reportFailure);
+        } else {
+          window.addEventListener(
+            "bitvid:nostr-tools-ready",
+            () => start(),
+            { once: true }
+          );
+        }
       });
     </script>
   </body>

--- a/components/iframe_forms/iframe-feedback-form.html
+++ b/components/iframe_forms/iframe-feedback-form.html
@@ -134,8 +134,36 @@
         scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
       }
     </style>
-    <!-- Load nostr‑tools v2.10.4 -->
-    <script src="https://cdn.jsdelivr.net/npm/nostr-tools@2.10.4/lib/nostr.bundle.min.js"></script>
+    <!-- Load nostr‑tools v2.10.4 and expose nip04 for legacy consumers -->
+    <script type="module">
+      const NOSTR_TOOLS_VERSION = "2.10.4";
+
+      const loadNostrTools = async () => {
+        const nostrModule = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`);
+        const { nip04 } = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`);
+
+        const toolsBundle = {
+          ...nostrModule,
+          nip04,
+        };
+
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
+
+        return toolsBundle;
+      };
+
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
+
+      window.NostrToolsReady = nostrToolsPromise;
+    </script>
   </head>
   <body>
     <div class="container">
@@ -255,202 +283,241 @@
     </div>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        // Logging function for on-page and console output.
-        function log(msg, type = "info") {
-          const div = document.createElement("div");
-          div.classList.add("status-line");
-          if (type === "error") div.classList.add("error");
-          if (type === "success") div.classList.add("success");
-          if (type === "warn") div.classList.add("warn");
-          div.textContent = msg;
-          document.getElementById("status").appendChild(div);
-          console.log(`[${type.toUpperCase()}] ${msg}`);
-        }
-        function clear() {
-          document.getElementById("status").innerHTML = "";
-        }
-        if (!window.NostrTools) {
-          log("NostrTools not loaded. Check console or ad-blockers.", "error");
+        let initialized = false;
+
+        const reportFailure = (error) => {
+          console.error("[bitvid] Failed to initialize feedback form", error);
+          const status = document.getElementById("status");
+          if (status) {
+            const div = document.createElement("div");
+            div.classList.add("status-line", "error");
+            div.textContent = "Failed to load Nostr tools. Please disable blockers and try again.";
+            status.appendChild(div);
+          }
+        };
+
+        const start = () => {
+          if (initialized) {
+            return;
+          }
+          if (!window.NostrTools) {
+            reportFailure(new Error("NostrTools not loaded."));
+            return;
+          }
+
+          initialized = true;
+
+          // Logging function for on-page and console output.
+          function log(msg, type = "info") {
+            const div = document.createElement("div");
+            div.classList.add("status-line");
+            if (type === "error") div.classList.add("error");
+            if (type === "success") div.classList.add("success");
+            if (type === "warn") div.classList.add("warn");
+            div.textContent = msg;
+            document.getElementById("status").appendChild(div);
+            console.log(`[${type.toUpperCase()}] ${msg}`);
+          }
+          function clear() {
+            document.getElementById("status").innerHTML = "";
+          }
+          const {
+            generateSecretKey,
+            getPublicKey,
+            finalizeEvent,
+            nip04,
+            nip19,
+            SimplePool,
+            Relay,
+          } = window.NostrTools;
+          
+          // Set the recipient's NPUB (your personal NPUB)
+          const recipientNpub =
+            "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
+          const RELAYS = [
+            "wss://relay.snort.social",
+            "wss://relay.damus.io",
+            "wss://relay.primal.net",
+          ];
+          const pool = new SimplePool();
+          
+          document
+            .getElementById("feedback-form")
+            .addEventListener("submit", async (ev) => {
+              ev.preventDefault();
+              clear();
+          
+              try {
+                // Section 1: User Information
+                const userNpub = document.getElementById("userNpub").value.trim();
+                const roleNodes = document.querySelectorAll(
+                  'input[name="userRole"]:checked'
+                );
+                let userRoles = [];
+                roleNodes.forEach((node) => {
+                  userRoles.push(node.value);
+                });
+          
+                // Section 2: General Feedback
+                const experienceRadio = document.querySelector(
+                  'input[name="experienceRating"]:checked'
+                );
+                const experienceRating = experienceRadio
+                  ? experienceRadio.value
+                  : "N/A";
+                const likeMost = document.getElementById("likeMost").value.trim();
+                const improvements = document
+                  .getElementById("improvements")
+                  .value.trim();
+                const confusingFeatures = document
+                  .getElementById("confusingFeatures")
+                  .value.trim();
+          
+                // Section 3: Additional Comments
+                const otherSuggestions = document
+                  .getElementById("otherSuggestions")
+                  .value.trim();
+                const followUp = document.getElementById("followUp").value.trim();
+                const preferredContact = document
+                  .getElementById("preferredContact")
+                  .value.trim();
+          
+                // Construct the Markdown feedback content
+                const feedbackContent = `
+          # **bitvid General Feedback Form**
+          
+          Your feedback helps us improve bitvid! Whether it’s a suggestion, a concern, or general thoughts on the platform, we’d love to hear from you.
+          
+          ## **1. User Information**
+          - **Nostr Public Key (npub) (optional):** ${userNpub || "N/A"}
+          - **Are you a (check all that apply):** ${
+                  userRoles.length > 0 ? userRoles.join(", ") : "N/A"
+                }
+          
+          ## **2. General Feedback**
+          - **How would you rate your experience on bitvid so far?** ${experienceRating}
+          - **What do you like most about bitvid?**  
+            ${likeMost || "N/A"}
+          - **What would you like to see improved?**  
+            ${improvements || "N/A"}
+          - **Are there any features or tools you find confusing or difficult to use?**  
+            ${confusingFeatures || "N/A"}
+          
+          ## **3. Additional Comments**
+          - **Do you have any other suggestions or thoughts about bitvid?**  
+            ${otherSuggestions || "N/A"}
+          - **Would you like to be contacted for follow-up discussions?** ${
+                  followUp || "N/A"
+                }
+          - **Preferred contact method (if applicable):** ${preferredContact || "N/A"}
+          
+          ---
+          ### **Processing & Consideration**
+          We review all feedback regularly to improve bitvid. While not all suggestions may be implemented, we greatly appreciate your input and strive to enhance the platform based on community insights.
+          
+          For additional discussions, reach out via bitvid’s Nostr support channels.
+              `.trim();
+          
+                log("[DEBUG] Constructed feedback content:
+" + feedbackContent);
+          
+                // Decode the recipient NPUB to get the public key.
+                log("Decoding recipient npub...");
+                const decoded = nip19.decode(recipientNpub);
+                log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
+                if (decoded.type !== "npub") {
+                  throw new Error("Decoded type is not npub.");
+                }
+                const targetPubHex = decoded.data;
+                log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
+          
+                // Generate an ephemeral key pair.
+                log("Generating ephemeral key...");
+                const ephemeralPriv = generateSecretKey();
+                const ephemeralPubHex = getPublicKey(ephemeralPriv);
+                log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
+          
+                // Encrypt the feedback content.
+                log("Encrypting feedback content (nip04)...");
+                const ciphertext = await nip04.encrypt(
+                  ephemeralPriv,
+                  targetPubHex,
+                  feedbackContent
+                );
+                log("[DEBUG] Ciphertext: " + ciphertext);
+                log("Encryption done.");
+          
+                // Build the event template.
+                const now = Math.floor(Date.now() / 1000);
+                const eventTemplate = {
+                  kind: 4,
+                  created_at: now,
+                  tags: [["p", targetPubHex]],
+                  content: ciphertext,
+                };
+                log(
+                  "[DEBUG] Event template before finalizing: " +
+                    JSON.stringify(eventTemplate)
+                );
+          
+                // Finalize the event.
+                const event = finalizeEvent(eventTemplate, ephemeralPriv);
+                log("[DEBUG] Final event: " + JSON.stringify(event));
+          
+                // Publish the event to all relays.
+                log("Publishing the feedback to relays...");
+                await Promise.any(pool.publish(RELAYS, event));
+                log("At least one relay accepted the event.", "success");
+          
+                // Subscribe to each relay to verify storage.
+                for (const url of RELAYS) {
+                  log("Connecting to " + url + " for subscription...");
+                  const relay = await Relay.connect(url);
+                  relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
+                    onEvent(foundEvent) {
+                      if (foundEvent.id === event.id) {
+                        log(
+                          "[" +
+                            url +
+                            "] => Found our feedback in storage! ID: " +
+                            foundEvent.id.slice(0, 8) +
+                            "...",
+                          "success"
+                        );
+                      }
+                    },
+                    onEose() {
+                      relay.close();
+                    },
+                  });
+                }
+          
+                log(
+                  "Done. If the logs show that at least one relay accepted the event and the feedback was stored, it will be reviewed accordingly."
+                );
+              } catch (err) {
+                log("Error: " + err.message, "error");
+                console.error(err);
+              }
+            });
+
+        };
+
+        if (window.NostrTools) {
+          start();
           return;
         }
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          nip04,
-          nip19,
-          SimplePool,
-          Relay,
-        } = window.NostrTools;
 
-        // Set the recipient's NPUB (your personal NPUB)
-        const recipientNpub =
-          "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
-        const RELAYS = [
-          "wss://relay.snort.social",
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-        ];
-        const pool = new SimplePool();
-
-        document
-          .getElementById("feedback-form")
-          .addEventListener("submit", async (ev) => {
-            ev.preventDefault();
-            clear();
-
-            try {
-              // Section 1: User Information
-              const userNpub = document.getElementById("userNpub").value.trim();
-              const roleNodes = document.querySelectorAll(
-                'input[name="userRole"]:checked'
-              );
-              let userRoles = [];
-              roleNodes.forEach((node) => {
-                userRoles.push(node.value);
-              });
-
-              // Section 2: General Feedback
-              const experienceRadio = document.querySelector(
-                'input[name="experienceRating"]:checked'
-              );
-              const experienceRating = experienceRadio
-                ? experienceRadio.value
-                : "N/A";
-              const likeMost = document.getElementById("likeMost").value.trim();
-              const improvements = document
-                .getElementById("improvements")
-                .value.trim();
-              const confusingFeatures = document
-                .getElementById("confusingFeatures")
-                .value.trim();
-
-              // Section 3: Additional Comments
-              const otherSuggestions = document
-                .getElementById("otherSuggestions")
-                .value.trim();
-              const followUp = document.getElementById("followUp").value.trim();
-              const preferredContact = document
-                .getElementById("preferredContact")
-                .value.trim();
-
-              // Construct the Markdown feedback content
-              const feedbackContent = `
-# **bitvid General Feedback Form**
-
-Your feedback helps us improve bitvid! Whether it’s a suggestion, a concern, or general thoughts on the platform, we’d love to hear from you.
-
-## **1. User Information**
-- **Nostr Public Key (npub) (optional):** ${userNpub || "N/A"}
-- **Are you a (check all that apply):** ${
-                userRoles.length > 0 ? userRoles.join(", ") : "N/A"
-              }
-
-## **2. General Feedback**
-- **How would you rate your experience on bitvid so far?** ${experienceRating}
-- **What do you like most about bitvid?**  
-  ${likeMost || "N/A"}
-- **What would you like to see improved?**  
-  ${improvements || "N/A"}
-- **Are there any features or tools you find confusing or difficult to use?**  
-  ${confusingFeatures || "N/A"}
-
-## **3. Additional Comments**
-- **Do you have any other suggestions or thoughts about bitvid?**  
-  ${otherSuggestions || "N/A"}
-- **Would you like to be contacted for follow-up discussions?** ${
-                followUp || "N/A"
-              }
-- **Preferred contact method (if applicable):** ${preferredContact || "N/A"}
-
----
-### **Processing & Consideration**
-We review all feedback regularly to improve bitvid. While not all suggestions may be implemented, we greatly appreciate your input and strive to enhance the platform based on community insights.
-
-For additional discussions, reach out via bitvid’s Nostr support channels.
-            `.trim();
-
-              log("[DEBUG] Constructed feedback content:\n" + feedbackContent);
-
-              // Decode the recipient NPUB to get the public key.
-              log("Decoding recipient npub...");
-              const decoded = nip19.decode(recipientNpub);
-              log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
-              if (decoded.type !== "npub") {
-                throw new Error("Decoded type is not npub.");
-              }
-              const targetPubHex = decoded.data;
-              log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
-
-              // Generate an ephemeral key pair.
-              log("Generating ephemeral key...");
-              const ephemeralPriv = generateSecretKey();
-              const ephemeralPubHex = getPublicKey(ephemeralPriv);
-              log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
-
-              // Encrypt the feedback content.
-              log("Encrypting feedback content (nip04)...");
-              const ciphertext = await nip04.encrypt(
-                ephemeralPriv,
-                targetPubHex,
-                feedbackContent
-              );
-              log("[DEBUG] Ciphertext: " + ciphertext);
-              log("Encryption done.");
-
-              // Build the event template.
-              const now = Math.floor(Date.now() / 1000);
-              const eventTemplate = {
-                kind: 4,
-                created_at: now,
-                tags: [["p", targetPubHex]],
-                content: ciphertext,
-              };
-              log(
-                "[DEBUG] Event template before finalizing: " +
-                  JSON.stringify(eventTemplate)
-              );
-
-              // Finalize the event.
-              const event = finalizeEvent(eventTemplate, ephemeralPriv);
-              log("[DEBUG] Final event: " + JSON.stringify(event));
-
-              // Publish the event to all relays.
-              log("Publishing the feedback to relays...");
-              await Promise.any(pool.publish(RELAYS, event));
-              log("At least one relay accepted the event.", "success");
-
-              // Subscribe to each relay to verify storage.
-              for (const url of RELAYS) {
-                log("Connecting to " + url + " for subscription...");
-                const relay = await Relay.connect(url);
-                relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
-                  onEvent(foundEvent) {
-                    if (foundEvent.id === event.id) {
-                      log(
-                        "[" +
-                          url +
-                          "] => Found our feedback in storage! ID: " +
-                          foundEvent.id.slice(0, 8) +
-                          "...",
-                        "success"
-                      );
-                    }
-                  },
-                  onEose() {
-                    relay.close();
-                  },
-                });
-              }
-
-              log(
-                "Done. If the logs show that at least one relay accepted the event and the feedback was stored, it will be reviewed accordingly."
-              );
-            } catch (err) {
-              log("Error: " + err.message, "error");
-              console.error(err);
-            }
-          });
+        const ready = window.NostrToolsReady;
+        if (ready && typeof ready.then === "function") {
+          ready.then(() => start()).catch(reportFailure);
+        } else {
+          window.addEventListener(
+            "bitvid:nostr-tools-ready",
+            () => start(),
+            { once: true }
+          );
+        }
       });
     </script>
   </body>

--- a/components/iframe_forms/iframe-request-form.html
+++ b/components/iframe_forms/iframe-request-form.html
@@ -126,8 +126,36 @@
         scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
       }
     </style>
-    <!-- Load nostr‑tools v2.10.4 -->
-    <script src="https://cdn.jsdelivr.net/npm/nostr-tools@2.10.4/lib/nostr.bundle.min.js"></script>
+    <!-- Load nostr‑tools v2.10.4 and expose nip04 for legacy consumers -->
+    <script type="module">
+      const NOSTR_TOOLS_VERSION = "2.10.4";
+
+      const loadNostrTools = async () => {
+        const nostrModule = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`);
+        const { nip04 } = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`);
+
+        const toolsBundle = {
+          ...nostrModule,
+          nip04,
+        };
+
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
+
+        return toolsBundle;
+      };
+
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
+
+      window.NostrToolsReady = nostrToolsPromise;
+    </script>
   </head>
   <body>
     <div class="container">
@@ -253,221 +281,260 @@
     </div>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        // Logging function
-        function log(msg, type = "info") {
-          const div = document.createElement("div");
-          div.classList.add("status-line");
-          if (type === "error") div.classList.add("error");
-          if (type === "success") div.classList.add("success");
-          if (type === "warn") div.classList.add("warn");
-          div.textContent = msg;
-          document.getElementById("status").appendChild(div);
-          console.log(`[${type.toUpperCase()}] ${msg}`);
-        }
-        function clear() {
-          document.getElementById("status").innerHTML = "";
-        }
-        if (!window.NostrTools) {
-          log("NostrTools not loaded. Check console or ad-blockers.", "error");
+        let initialized = false;
+
+        const reportFailure = (error) => {
+          console.error("[bitvid] Failed to initialize feature request form", error);
+          const status = document.getElementById("status");
+          if (status) {
+            const div = document.createElement("div");
+            div.classList.add("status-line", "error");
+            div.textContent = "Failed to load Nostr tools. Please disable blockers and try again.";
+            status.appendChild(div);
+          }
+        };
+
+        const start = () => {
+          if (initialized) {
+            return;
+          }
+          if (!window.NostrTools) {
+            reportFailure(new Error("NostrTools not loaded."));
+            return;
+          }
+
+          initialized = true;
+
+          // Logging function
+          function log(msg, type = "info") {
+            const div = document.createElement("div");
+            div.classList.add("status-line");
+            if (type === "error") div.classList.add("error");
+            if (type === "success") div.classList.add("success");
+            if (type === "warn") div.classList.add("warn");
+            div.textContent = msg;
+            document.getElementById("status").appendChild(div);
+            console.log(`[${type.toUpperCase()}] ${msg}`);
+          }
+          function clear() {
+            document.getElementById("status").innerHTML = "";
+          }
+          const {
+            generateSecretKey,
+            getPublicKey,
+            finalizeEvent,
+            nip04,
+            nip19,
+            SimplePool,
+            Relay,
+          } = window.NostrTools;
+          
+          // Set the recipient's NPUB (your personal NPUB)
+          const recipientNpub =
+            "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
+          const RELAYS = [
+            "wss://relay.snort.social",
+            "wss://relay.damus.io",
+            "wss://relay.primal.net",
+          ];
+          const pool = new SimplePool();
+          
+          document
+            .getElementById("feature-form")
+            .addEventListener("submit", async (ev) => {
+              ev.preventDefault();
+              clear();
+              try {
+                // Section 1: User Information
+                const userNpub = document.getElementById("userNpub").value.trim();
+                const roleNodes = document.querySelectorAll(
+                  'input[name="userRole"]:checked'
+                );
+                let userRoles = [];
+                roleNodes.forEach((node) => {
+                  userRoles.push(node.value);
+                });
+          
+                // Section 2: Feature Request Details
+                const featureName = document
+                  .getElementById("featureName")
+                  .value.trim();
+                const featureDescription = document
+                  .getElementById("featureDescription")
+                  .value.trim();
+                const featureImportance = document
+                  .getElementById("featureImportance")
+                  .value.trim();
+                const beneficiary = document
+                  .getElementById("beneficiary")
+                  .value.trim();
+          
+                // Section 3: Additional Information
+                const existingPlatforms = document
+                  .getElementById("existingPlatforms")
+                  .value.trim();
+                const mockups = document.getElementById("mockups").value.trim();
+                const willingToTest = document
+                  .getElementById("willingToTest")
+                  .value.trim();
+          
+                // Section 4: Priority & Impact
+                const priorityNodes = document.querySelectorAll(
+                  'input[name="featurePriority"]:checked'
+                );
+                let featurePriorities = [];
+                priorityNodes.forEach((node) => {
+                  featurePriorities.push(node.value);
+                });
+                const techChallenges = document
+                  .getElementById("techChallenges")
+                  .value.trim();
+          
+                // Construct Markdown feature request
+                const featureRequestContent = `
+          # **bitvid Feature Request Form**
+          
+          Have an idea for improving bitvid? We’d love to hear it! Please use this form to request new features or enhancements. Your feedback helps shape the future of bitvid.
+          
+          ## **1. User Information**
+          - **Nostr Public Key (npub) (optional):** ${userNpub || "N/A"}
+          - **Roles:** ${userRoles.length > 0 ? userRoles.join(", ") : "N/A"}
+          
+          ## **2. Feature Request Details**
+          - **Feature Name:** ${featureName || "N/A"}
+          - **Describe the feature:**  
+            ${featureDescription || "N/A"}
+          - **Why is this feature important?**  
+            ${featureImportance || "N/A"}
+          - **Who would benefit from this feature?**  
+            ${beneficiary || "N/A"}
+          
+          ## **3. Additional Information**
+          - **Are there existing platforms that have this feature?**  
+            ${existingPlatforms || "N/A"}
+          - **Do you have any mockups or examples?**  
+            ${mockups || "N/A"}
+          - **Would you be willing to help test this feature if implemented?** ${
+                  willingToTest || "N/A"
+                }
+          
+          ## **4. Priority & Impact**
+          - **How urgent is this feature?**  
+            ${featurePriorities.length > 0 ? featurePriorities.join(", ") : "N/A"}
+          - **Does this feature require technical expertise to implement?**  
+            ${techChallenges || "N/A"}
+          
+          ---
+          
+          ### **Processing & Consideration**
+          All feature requests are reviewed, but not all may be implemented. We prioritize based on user demand, feasibility, and impact on bitvid. Thank you for helping us improve!
+          
+          For further discussions, reach out through bitvid’s Nostr support channels.
+              `.trim();
+          
+                log(
+                  "[DEBUG] Constructed feature request content:
+" +
+                    featureRequestContent
+                );
+          
+                // Decode the recipient NPUB
+                log("Decoding recipient npub...");
+                const decoded = nip19.decode(recipientNpub);
+                log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
+                if (decoded.type !== "npub") {
+                  throw new Error("Decoded type is not npub.");
+                }
+                const targetPubHex = decoded.data;
+                log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
+          
+                // Generate an ephemeral key pair
+                log("Generating ephemeral key...");
+                const ephemeralPriv = generateSecretKey();
+                const ephemeralPubHex = getPublicKey(ephemeralPriv);
+                log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
+          
+                // Encrypt the feature request content
+                log("Encrypting feature request content (nip04)...");
+                const ciphertext = await nip04.encrypt(
+                  ephemeralPriv,
+                  targetPubHex,
+                  featureRequestContent
+                );
+                log("[DEBUG] Ciphertext: " + ciphertext);
+                log("Encryption done.");
+          
+                // Build the event template
+                const now = Math.floor(Date.now() / 1000);
+                const eventTemplate = {
+                  kind: 4,
+                  created_at: now,
+                  tags: [["p", targetPubHex]],
+                  content: ciphertext,
+                };
+                log(
+                  "[DEBUG] Event template before finalizing: " +
+                    JSON.stringify(eventTemplate)
+                );
+          
+                // Finalize the event
+                const event = finalizeEvent(eventTemplate, ephemeralPriv);
+                log("[DEBUG] Final event: " + JSON.stringify(event));
+          
+                // Publish to relays
+                log("Publishing the feature request to relays...");
+                await Promise.any(pool.publish(RELAYS, event));
+                log("At least one relay accepted the event.", "success");
+          
+                // Subscribe to verify event storage
+                for (const url of RELAYS) {
+                  log("Connecting to " + url + " for subscription...");
+                  const relay = await Relay.connect(url);
+                  relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
+                    onEvent(foundEvent) {
+                      if (foundEvent.id === event.id) {
+                        log(
+                          "[" +
+                            url +
+                            "] => Found our feature request in storage! ID: " +
+                            foundEvent.id.slice(0, 8) +
+                            "...",
+                          "success"
+                        );
+                      }
+                    },
+                    onEose() {
+                      relay.close();
+                    },
+                  });
+                }
+          
+                log(
+                  "Done. If the logs show that at least one relay accepted the event and the feature request was stored, it will be reviewed accordingly."
+                );
+              } catch (err) {
+                log("Error: " + err.message, "error");
+                console.error(err);
+              }
+            });
+
+        };
+
+        if (window.NostrTools) {
+          start();
           return;
         }
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          nip04,
-          nip19,
-          SimplePool,
-          Relay,
-        } = window.NostrTools;
 
-        // Set the recipient's NPUB (your personal NPUB)
-        const recipientNpub =
-          "npub13yarr7j6vjqjjkahd63dmr27curypehx45ucue286ac7sft27y0srnpmpe";
-        const RELAYS = [
-          "wss://relay.snort.social",
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-        ];
-        const pool = new SimplePool();
-
-        document
-          .getElementById("feature-form")
-          .addEventListener("submit", async (ev) => {
-            ev.preventDefault();
-            clear();
-            try {
-              // Section 1: User Information
-              const userNpub = document.getElementById("userNpub").value.trim();
-              const roleNodes = document.querySelectorAll(
-                'input[name="userRole"]:checked'
-              );
-              let userRoles = [];
-              roleNodes.forEach((node) => {
-                userRoles.push(node.value);
-              });
-
-              // Section 2: Feature Request Details
-              const featureName = document
-                .getElementById("featureName")
-                .value.trim();
-              const featureDescription = document
-                .getElementById("featureDescription")
-                .value.trim();
-              const featureImportance = document
-                .getElementById("featureImportance")
-                .value.trim();
-              const beneficiary = document
-                .getElementById("beneficiary")
-                .value.trim();
-
-              // Section 3: Additional Information
-              const existingPlatforms = document
-                .getElementById("existingPlatforms")
-                .value.trim();
-              const mockups = document.getElementById("mockups").value.trim();
-              const willingToTest = document
-                .getElementById("willingToTest")
-                .value.trim();
-
-              // Section 4: Priority & Impact
-              const priorityNodes = document.querySelectorAll(
-                'input[name="featurePriority"]:checked'
-              );
-              let featurePriorities = [];
-              priorityNodes.forEach((node) => {
-                featurePriorities.push(node.value);
-              });
-              const techChallenges = document
-                .getElementById("techChallenges")
-                .value.trim();
-
-              // Construct Markdown feature request
-              const featureRequestContent = `
-# **bitvid Feature Request Form**
-
-Have an idea for improving bitvid? We’d love to hear it! Please use this form to request new features or enhancements. Your feedback helps shape the future of bitvid.
-
-## **1. User Information**
-- **Nostr Public Key (npub) (optional):** ${userNpub || "N/A"}
-- **Roles:** ${userRoles.length > 0 ? userRoles.join(", ") : "N/A"}
-
-## **2. Feature Request Details**
-- **Feature Name:** ${featureName || "N/A"}
-- **Describe the feature:**  
-  ${featureDescription || "N/A"}
-- **Why is this feature important?**  
-  ${featureImportance || "N/A"}
-- **Who would benefit from this feature?**  
-  ${beneficiary || "N/A"}
-
-## **3. Additional Information**
-- **Are there existing platforms that have this feature?**  
-  ${existingPlatforms || "N/A"}
-- **Do you have any mockups or examples?**  
-  ${mockups || "N/A"}
-- **Would you be willing to help test this feature if implemented?** ${
-                willingToTest || "N/A"
-              }
-
-## **4. Priority & Impact**
-- **How urgent is this feature?**  
-  ${featurePriorities.length > 0 ? featurePriorities.join(", ") : "N/A"}
-- **Does this feature require technical expertise to implement?**  
-  ${techChallenges || "N/A"}
-
----
-
-### **Processing & Consideration**
-All feature requests are reviewed, but not all may be implemented. We prioritize based on user demand, feasibility, and impact on bitvid. Thank you for helping us improve!
-
-For further discussions, reach out through bitvid’s Nostr support channels.
-            `.trim();
-
-              log(
-                "[DEBUG] Constructed feature request content:\n" +
-                  featureRequestContent
-              );
-
-              // Decode the recipient NPUB
-              log("Decoding recipient npub...");
-              const decoded = nip19.decode(recipientNpub);
-              log("[DEBUG] Decoded npub: " + JSON.stringify(decoded));
-              if (decoded.type !== "npub") {
-                throw new Error("Decoded type is not npub.");
-              }
-              const targetPubHex = decoded.data;
-              log("Recipient pubkey: " + targetPubHex.slice(0, 16) + "...");
-
-              // Generate an ephemeral key pair
-              log("Generating ephemeral key...");
-              const ephemeralPriv = generateSecretKey();
-              const ephemeralPubHex = getPublicKey(ephemeralPriv);
-              log("Ephemeral pubkey: " + ephemeralPubHex.slice(0, 16) + "...");
-
-              // Encrypt the feature request content
-              log("Encrypting feature request content (nip04)...");
-              const ciphertext = await nip04.encrypt(
-                ephemeralPriv,
-                targetPubHex,
-                featureRequestContent
-              );
-              log("[DEBUG] Ciphertext: " + ciphertext);
-              log("Encryption done.");
-
-              // Build the event template
-              const now = Math.floor(Date.now() / 1000);
-              const eventTemplate = {
-                kind: 4,
-                created_at: now,
-                tags: [["p", targetPubHex]],
-                content: ciphertext,
-              };
-              log(
-                "[DEBUG] Event template before finalizing: " +
-                  JSON.stringify(eventTemplate)
-              );
-
-              // Finalize the event
-              const event = finalizeEvent(eventTemplate, ephemeralPriv);
-              log("[DEBUG] Final event: " + JSON.stringify(event));
-
-              // Publish to relays
-              log("Publishing the feature request to relays...");
-              await Promise.any(pool.publish(RELAYS, event));
-              log("At least one relay accepted the event.", "success");
-
-              // Subscribe to verify event storage
-              for (const url of RELAYS) {
-                log("Connecting to " + url + " for subscription...");
-                const relay = await Relay.connect(url);
-                relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
-                  onEvent(foundEvent) {
-                    if (foundEvent.id === event.id) {
-                      log(
-                        "[" +
-                          url +
-                          "] => Found our feature request in storage! ID: " +
-                          foundEvent.id.slice(0, 8) +
-                          "...",
-                        "success"
-                      );
-                    }
-                  },
-                  onEose() {
-                    relay.close();
-                  },
-                });
-              }
-
-              log(
-                "Done. If the logs show that at least one relay accepted the event and the feature request was stored, it will be reviewed accordingly."
-              );
-            } catch (err) {
-              log("Error: " + err.message, "error");
-              console.error(err);
-            }
-          });
+        const ready = window.NostrToolsReady;
+        if (ready && typeof ready.then === "function") {
+          ready.then(() => start()).catch(reportFailure);
+        } else {
+          window.addEventListener(
+            "bitvid:nostr-tools-ready",
+            () => start(),
+            { once: true }
+          );
+        }
       });
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -199,55 +199,53 @@
 
     <!-- Additional Scripts -->
     <script type="module">
-      import * as nostrTools from "https://esm.sh/nostr-tools@1.8.3";
+      const NOSTR_TOOLS_VERSION = "2.10.4";
 
-      const normalizedGeneratePrivateKey =
-        typeof nostrTools.generatePrivateKey === "function"
-          ? nostrTools.generatePrivateKey
-          : typeof nostrTools.generateSecretKey === "function"
-          ? nostrTools.generateSecretKey
-          : undefined;
+      const loadNostrTools = async () => {
+        const nostrModule = await import(
+          `https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`
+        );
+        const { nip04 } = await import(
+          `https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`
+        );
 
-      const normalizedGenerateSecretKey =
-        typeof nostrTools.generateSecretKey === "function"
-          ? nostrTools.generateSecretKey
-          : typeof nostrTools.generatePrivateKey === "function"
-          ? nostrTools.generatePrivateKey
-          : undefined;
+        const normalizedGeneratePrivateKey =
+          typeof nostrModule.generatePrivateKey === "function"
+            ? nostrModule.generatePrivateKey
+            : typeof nostrModule.generateSecretKey === "function"
+            ? nostrModule.generateSecretKey
+            : undefined;
 
-      const hasWorkingNip04 = (candidate) =>
-        candidate &&
-        typeof candidate.encrypt === "function" &&
-        typeof candidate.decrypt === "function";
+        const normalizedGenerateSecretKey =
+          typeof nostrModule.generateSecretKey === "function"
+            ? nostrModule.generateSecretKey
+            : typeof nostrModule.generatePrivateKey === "function"
+            ? nostrModule.generatePrivateKey
+            : undefined;
 
-      let resolvedNip04 = hasWorkingNip04(nostrTools?.nip04)
-        ? nostrTools.nip04
-        : null;
+        const toolsBundle = {
+          ...nostrModule,
+          generatePrivateKey: normalizedGeneratePrivateKey,
+          generateSecretKey: normalizedGenerateSecretKey,
+          nip04,
+        };
 
-      if (!resolvedNip04) {
-        try {
-          const fallbackModule = await import(
-            "https://esm.sh/nostr-tools@1.8.3?target=es2022&exports=nip04"
-          );
-          if (hasWorkingNip04(fallbackModule?.nip04)) {
-            resolvedNip04 = fallbackModule.nip04;
-          }
-        } catch (error) {
-          console.warn("[bitvid] Failed to load nostr nip04 helper", error);
-        }
-      }
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
 
-      const toolsBundle = {
-        ...nostrTools,
-        generatePrivateKey: normalizedGeneratePrivateKey,
-        generateSecretKey: normalizedGenerateSecretKey,
+        return toolsBundle;
       };
 
-      if (resolvedNip04) {
-        toolsBundle.nip04 = resolvedNip04;
-      }
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
 
-      window.NostrTools = toolsBundle;
+      window.NostrToolsReady = nostrToolsPromise;
     </script>
     <script type="module" src="js/config.js"></script>
     <script type="module" src="js/lists.js"></script>

--- a/tests/nostr-ephemeral-dm-tester.html
+++ b/tests/nostr-ephemeral-dm-tester.html
@@ -84,8 +84,36 @@
         - Nostr protocol specifications and community examples.
     -->
 
-    <!-- Load nostr‑tools v2.10.4 -->
-    <script src="https://cdn.jsdelivr.net/npm/nostr-tools@2.10.4/lib/nostr.bundle.min.js"></script>
+    <!-- Load nostr‑tools v2.10.4 and expose nip04 for legacy consumers -->
+    <script type="module">
+      const NOSTR_TOOLS_VERSION = "2.10.4";
+
+      const loadNostrTools = async () => {
+        const nostrModule = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}`);
+        const { nip04 } = await import(`https://esm.sh/nostr-tools@${NOSTR_TOOLS_VERSION}/nip04`);
+
+        const toolsBundle = {
+          ...nostrModule,
+          nip04,
+        };
+
+        window.NostrTools = toolsBundle;
+        window.dispatchEvent(
+          new CustomEvent("bitvid:nostr-tools-ready", {
+            detail: { nostrTools: toolsBundle },
+          })
+        );
+
+        return toolsBundle;
+      };
+
+      const nostrToolsPromise = loadNostrTools().catch((error) => {
+        console.error("[bitvid] Failed to load nostr-tools", error);
+        throw error;
+      });
+
+      window.NostrToolsReady = nostrToolsPromise;
+    </script>
   </head>
   <body>
     <h1>Nostr Ephemeral DM Tester (Using finalizeEvent)</h1>
@@ -118,146 +146,184 @@
 
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        // Logging functions for both on-page and console output.
-        function log(msg, type = "info") {
-          const div = document.createElement("div");
-          div.classList.add("status-line");
-          if (type === "error") div.classList.add("error");
-          if (type === "success") div.classList.add("success");
-          if (type === "warn") div.classList.add("warn");
-          div.textContent = msg;
-          document.getElementById("status").appendChild(div);
-          console.log(`[${type.toUpperCase()}] ${msg}`);
-        }
-        function clear() {
-          document.getElementById("status").innerHTML = "";
-        }
+        let initialized = false;
 
-        if (!window.NostrTools) {
-          log("NostrTools not loaded. Check console or ad-blockers.", "error");
+        const reportFailure = (error) => {
+          console.error("[bitvid] Failed to initialize DM tester", error);
+          const status = document.getElementById("status");
+          if (status) {
+            const div = document.createElement("div");
+            div.classList.add("status-line", "error");
+            div.textContent = "Failed to load Nostr tools. Please disable blockers and try again.";
+            status.appendChild(div);
+          }
+        };
+
+        const start = () => {
+          if (initialized) {
+            return;
+          }
+          if (!window.NostrTools) {
+            reportFailure(new Error("NostrTools not loaded."));
+            return;
+          }
+
+          initialized = true;
+
+          // Logging functions for both on-page and console output.
+          function log(msg, type = "info") {
+            const div = document.createElement("div");
+            div.classList.add("status-line");
+            if (type === "error") div.classList.add("error");
+            if (type === "success") div.classList.add("success");
+            if (type === "warn") div.classList.add("warn");
+            div.textContent = msg;
+            document.getElementById("status").appendChild(div);
+            console.log(`[${type.toUpperCase()}] ${msg}`);
+          }
+          function clear() {
+            document.getElementById("status").innerHTML = "";
+          }
+          
+          
+          // Destructure the required functions and classes from nostr-tools.
+          // finalizeEvent is used to automatically compute the event id, sign the event, and assign the pubkey.
+          const {
+            generateSecretKey,
+            getPublicKey,
+            finalizeEvent,
+            nip04,
+            nip19,
+            SimplePool,
+            utils,
+            Relay, // Relay API for subscriptions.
+          } = window.NostrTools;
+          
+          // Define relay URLs.
+          const RELAYS = [
+            "wss://relay.snort.social",
+            "wss://relay.damus.io",
+            "wss://relay.primal.net",
+          ];
+          
+          // Create a SimplePool instance for publishing events.
+          const pool = new SimplePool();
+          
+          // Main form submission handler.
+          document
+            .getElementById("dm-form")
+            .addEventListener("submit", async (ev) => {
+              ev.preventDefault();
+              clear();
+          
+              try {
+                // 1) Retrieve and validate user input.
+                const npub = document.getElementById("npubInput").value.trim();
+                if (!npub.startsWith("npub")) {
+                  throw new Error("Target must start with npub.");
+                }
+                const message =
+                  document.getElementById("msgInput").value.trim() ||
+                  "Hello from ephemeral DM!";
+          
+                // 2) Decode the npub to obtain the target public key.
+                log("Decoding target npub...");
+                const decoded = nip19.decode(npub);
+                log(`[DEBUG] Decoded npub: ${JSON.stringify(decoded)}`);
+                if (decoded.type !== "npub") {
+                  throw new Error("Decoded type is not npub.");
+                }
+                const targetPubHex = decoded.data;
+                log(`Target pubkey: ${targetPubHex.slice(0, 16)}...`);
+          
+                // 3) Generate an ephemeral key pair.
+                log("Generating ephemeral key...");
+                const ephemeralPriv = generateSecretKey(); // Returns a Uint8Array.
+                const ephemeralPubHex = getPublicKey(ephemeralPriv); // Returns a hex string.
+                log(`Ephemeral pubkey: ${ephemeralPubHex.slice(0, 16)}...`);
+          
+                // 4) Encrypt the message using NIP‑04 encryption.
+                log("Encrypting message (nip04)...");
+                const ciphertext = await nip04.encrypt(
+                  ephemeralPriv,
+                  targetPubHex,
+                  message
+                );
+                log(`[DEBUG] Ciphertext: ${ciphertext}`);
+                log("Encryption done.");
+          
+                // 5) Build the DM event template (without id and signature).
+                const now = Math.floor(Date.now() / 1000);
+                const eventTemplate = {
+                  kind: 4,
+                  created_at: now,
+                  tags: [["p", targetPubHex]],
+                  content: ciphertext,
+                };
+                log(
+                  `[DEBUG] Event template before finalizing: ${JSON.stringify(
+                    eventTemplate
+                  )}`
+                );
+          
+                // 6) Finalize the event: compute the event id, sign it, and assign the pubkey.
+                const event = finalizeEvent(eventTemplate, ephemeralPriv);
+                log(`[DEBUG] Final event: ${JSON.stringify(event)}`);
+          
+                // 7) Publish the event to all relays.
+                log("Publishing to relays...");
+                // pool.publish now accepts an array of relay URLs and returns a promise.
+                await Promise.any(pool.publish(RELAYS, event));
+                log("At least one relay accepted the event.", "success");
+          
+                // 8) For each relay, connect using the Relay API and subscribe to verify event storage.
+                for (const url of RELAYS) {
+                  log(`Connecting to ${url} for subscription...`);
+                  const relay = await Relay.connect(url);
+                  relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
+                    onEvent(foundEvent) {
+                      if (foundEvent.id === event.id) {
+                        log(
+                          `[${url}] => Found our DM in storage! ID: ${foundEvent.id.slice(
+                            0,
+                            8
+                          )}...`,
+                          "success"
+                        );
+                      }
+                    },
+                    onEose() {
+                      relay.close();
+                    },
+                  });
+                }
+          
+                log(
+                  "Done. If the logs show 'Relay accepted' and 'Found our DM in storage', the event is on at least one relay. Another client must subscribe to ephemeralPubHex or #p=targetPubHex to see it."
+                );
+              } catch (err) {
+                log("Error: " + err.message, "error");
+                console.error(err);
+              }
+            });
+
+        };
+
+        if (window.NostrTools) {
+          start();
           return;
         }
 
-        // Destructure the required functions and classes from nostr-tools.
-        // finalizeEvent is used to automatically compute the event id, sign the event, and assign the pubkey.
-        const {
-          generateSecretKey,
-          getPublicKey,
-          finalizeEvent,
-          nip04,
-          nip19,
-          SimplePool,
-          utils,
-          Relay, // Relay API for subscriptions.
-        } = window.NostrTools;
-
-        // Define relay URLs.
-        const RELAYS = [
-          "wss://relay.snort.social",
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-        ];
-
-        // Create a SimplePool instance for publishing events.
-        const pool = new SimplePool();
-
-        // Main form submission handler.
-        document
-          .getElementById("dm-form")
-          .addEventListener("submit", async (ev) => {
-            ev.preventDefault();
-            clear();
-
-            try {
-              // 1) Retrieve and validate user input.
-              const npub = document.getElementById("npubInput").value.trim();
-              if (!npub.startsWith("npub")) {
-                throw new Error("Target must start with npub.");
-              }
-              const message =
-                document.getElementById("msgInput").value.trim() ||
-                "Hello from ephemeral DM!";
-
-              // 2) Decode the npub to obtain the target public key.
-              log("Decoding target npub...");
-              const decoded = nip19.decode(npub);
-              log(`[DEBUG] Decoded npub: ${JSON.stringify(decoded)}`);
-              if (decoded.type !== "npub") {
-                throw new Error("Decoded type is not npub.");
-              }
-              const targetPubHex = decoded.data;
-              log(`Target pubkey: ${targetPubHex.slice(0, 16)}...`);
-
-              // 3) Generate an ephemeral key pair.
-              log("Generating ephemeral key...");
-              const ephemeralPriv = generateSecretKey(); // Returns a Uint8Array.
-              const ephemeralPubHex = getPublicKey(ephemeralPriv); // Returns a hex string.
-              log(`Ephemeral pubkey: ${ephemeralPubHex.slice(0, 16)}...`);
-
-              // 4) Encrypt the message using NIP‑04 encryption.
-              log("Encrypting message (nip04)...");
-              const ciphertext = await nip04.encrypt(
-                ephemeralPriv,
-                targetPubHex,
-                message
-              );
-              log(`[DEBUG] Ciphertext: ${ciphertext}`);
-              log("Encryption done.");
-
-              // 5) Build the DM event template (without id and signature).
-              const now = Math.floor(Date.now() / 1000);
-              const eventTemplate = {
-                kind: 4,
-                created_at: now,
-                tags: [["p", targetPubHex]],
-                content: ciphertext,
-              };
-              log(
-                `[DEBUG] Event template before finalizing: ${JSON.stringify(
-                  eventTemplate
-                )}`
-              );
-
-              // 6) Finalize the event: compute the event id, sign it, and assign the pubkey.
-              const event = finalizeEvent(eventTemplate, ephemeralPriv);
-              log(`[DEBUG] Final event: ${JSON.stringify(event)}`);
-
-              // 7) Publish the event to all relays.
-              log("Publishing to relays...");
-              // pool.publish now accepts an array of relay URLs and returns a promise.
-              await Promise.any(pool.publish(RELAYS, event));
-              log("At least one relay accepted the event.", "success");
-
-              // 8) For each relay, connect using the Relay API and subscribe to verify event storage.
-              for (const url of RELAYS) {
-                log(`Connecting to ${url} for subscription...`);
-                const relay = await Relay.connect(url);
-                relay.subscribe([{ authors: [ephemeralPubHex], kinds: [4] }], {
-                  onEvent(foundEvent) {
-                    if (foundEvent.id === event.id) {
-                      log(
-                        `[${url}] => Found our DM in storage! ID: ${foundEvent.id.slice(
-                          0,
-                          8
-                        )}...`,
-                        "success"
-                      );
-                    }
-                  },
-                  onEose() {
-                    relay.close();
-                  },
-                });
-              }
-
-              log(
-                "Done. If the logs show 'Relay accepted' and 'Found our DM in storage', the event is on at least one relay. Another client must subscribe to ephemeralPubHex or #p=targetPubHex to see it."
-              );
-            } catch (err) {
-              log("Error: " + err.message, "error");
-              console.error(err);
-            }
-          });
+        const ready = window.NostrToolsReady;
+        if (ready && typeof ready.then === "function") {
+          ready.then(() => start()).catch(reportFailure);
+        } else {
+          window.addEventListener(
+            "bitvid:nostr-tools-ready",
+            () => start(),
+            { once: true }
+          );
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- load nostr-tools v2.10.4 from index.html with a readiness promise/event so nip04 is always exposed before zap flows run
- update the standalone iframe forms and DM tester to use the same loader, wait on `NostrToolsReady`, and show a friendly error if tools fail to initialize

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e20666cc94832bafbe517cac056779