### PR TITLE
Ensure NostrTools nip04 support survives external overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,25 +268,27 @@
       if (nostrTools && typeof nostrTools === "object") {
         toolSources.push(nostrTools);
       }
-      const globalTools =
-        typeof window !== "undefined" && window?.NostrTools
-          ? window.NostrTools
+      const globalScope =
+        typeof window !== "undefined" ? window : typeof globalThis !== "undefined" ? globalThis : null;
+      const existingTools =
+        globalScope && typeof globalScope.NostrTools === "object"
+          ? globalScope.NostrTools
           : null;
-      if (globalTools && globalTools !== nostrTools) {
-        toolSources.push(globalTools);
+      if (existingTools && existingTools !== nostrTools) {
+        toolSources.push(existingTools);
       }
 
-      const toolsBundle = Object.assign({}, ...toolSources);
+      const canonicalTools = Object.assign({}, ...toolSources);
 
       if (normalizedGeneratePrivateKey) {
-        toolsBundle.generatePrivateKey = normalizedGeneratePrivateKey;
+        canonicalTools.generatePrivateKey = normalizedGeneratePrivateKey;
       }
       if (normalizedGenerateSecretKey) {
-        toolsBundle.generateSecretKey = normalizedGenerateSecretKey;
+        canonicalTools.generateSecretKey = normalizedGenerateSecretKey;
       }
 
       if (resolvedNip04) {
-        toolsBundle.nip04 = resolvedNip04;
+        canonicalTools.nip04 = resolvedNip04;
         console.info(
           `[bitvid] Initialized nostr nip04 helpers using ${nip04Source}.`,
         );
@@ -296,7 +298,55 @@
         );
       }
 
-      window.NostrTools = toolsBundle;
+      if (globalScope) {
+        try {
+          Object.defineProperty(globalScope, "__BITVID_CANONICAL_NOSTR_TOOLS__", {
+            value: Object.freeze({ ...canonicalTools }),
+            writable: false,
+            enumerable: false,
+            configurable: true,
+          });
+        } catch (error) {
+          globalScope.__BITVID_CANONICAL_NOSTR_TOOLS__ = Object.freeze({
+            ...canonicalTools,
+          });
+        }
+
+        let activeTools = canonicalTools;
+        const mergeWithCanonical = (candidate) => {
+          if (!candidate || typeof candidate !== "object") {
+            return canonicalTools;
+          }
+          const merged = Object.assign({}, canonicalTools, candidate);
+          if (!merged.nip04 && canonicalTools.nip04) {
+            merged.nip04 = canonicalTools.nip04;
+          }
+          return merged;
+        };
+
+        const applyActive = (candidate) => {
+          activeTools = mergeWithCanonical(candidate);
+          return activeTools;
+        };
+
+        try {
+          Object.defineProperty(globalScope, "NostrTools", {
+            configurable: true,
+            enumerable: true,
+            get() {
+              return activeTools;
+            },
+            set(value) {
+              applyActive(value);
+            },
+          });
+        } catch (error) {
+          console.warn("[bitvid] Failed to install NostrTools guard.", error);
+        }
+
+        applyActive(existingTools);
+        globalScope.NostrTools = canonicalTools;
+      }
     </script>
     <script type="module" src="js/config.js"></script>
     <script type="module" src="js/lists.js"></script>

--- a/js/payments/nwcClient.js
+++ b/js/payments/nwcClient.js
@@ -29,7 +29,22 @@ function getGlobalWindow() {
 
 function getNostrTools() {
   const win = getGlobalWindow();
-  return win?.NostrTools || null;
+  const tools = win?.NostrTools || null;
+  const canonical = win?.__BITVID_CANONICAL_NOSTR_TOOLS__ || null;
+
+  if (tools && canonical && !tools.nip04 && canonical.nip04) {
+    try {
+      tools.nip04 = canonical.nip04;
+    } catch (error) {
+      return { ...canonical, ...tools, nip04: canonical.nip04 };
+    }
+  }
+
+  if (tools) {
+    return tools;
+  }
+
+  return canonical || null;
 }
 
 function assertNostrTools(methods = []) {

--- a/js/payments/platformAddress.js
+++ b/js/payments/platformAddress.js
@@ -21,7 +21,18 @@ function getGlobalWindow() {
 
 function getNostrTools() {
   const win = getGlobalWindow();
-  return win?.NostrTools || null;
+  const tools = win?.NostrTools || null;
+  const canonical = win?.__BITVID_CANONICAL_NOSTR_TOOLS__ || null;
+
+  if (tools && canonical && !tools.nip04 && canonical.nip04) {
+    try {
+      tools.nip04 = canonical.nip04;
+    } catch (error) {
+      return { ...canonical, ...tools, nip04: canonical.nip04 };
+    }
+  }
+
+  return tools || canonical || null;
 }
 
 function decodeAdminPubkey() {

--- a/js/payments/zapSplit.js
+++ b/js/payments/zapSplit.js
@@ -81,12 +81,30 @@ function mergeDependencies(overrides = {}) {
 }
 
 function getNostrTools() {
-  if (typeof window !== "undefined" && window?.NostrTools) {
-    return window.NostrTools;
+  const scope = typeof window !== "undefined" ? window : globalThis;
+  const tools = scope?.NostrTools || null;
+  const canonical = scope?.__BITVID_CANONICAL_NOSTR_TOOLS__ || null;
+
+  if (tools && canonical && !tools.nip04 && canonical.nip04) {
+    try {
+      tools.nip04 = canonical.nip04;
+    } catch (error) {
+      return { ...canonical, ...tools, nip04: canonical.nip04 };
+    }
   }
+
+  if (tools) {
+    return tools;
+  }
+
+  if (canonical) {
+    return canonical;
+  }
+
   if (typeof globalThis !== "undefined" && globalThis?.NostrTools) {
     return globalThis.NostrTools;
   }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- guard the browser's NostrTools binding so the canonical nip04 helper persists even if extensions overwrite it
- reuse the stored canonical nostr-tools object inside the payment helpers when nip04 is missing from the active binding

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e212cfd0e8832b9f288084542114b9