### PR TITLE
Fix channel zap share amount tracking

### DIFF
--- a/js/channelProfile.js
+++ b/js/channelProfile.js
@@ -556,7 +556,7 @@ function createZapDependencies({ creatorEntry, platformEntry, shares, shareTrack
       },
       sendPayment: async (bolt11, params) => {
         const shareType = activeShare || "unknown";
-        const amount =
+        const shareAmount =
           shareType === "platform"
             ? shares.platformShare
             : shares.creatorShare;
@@ -570,7 +570,7 @@ function createZapDependencies({ creatorEntry, platformEntry, shares, shareTrack
             shareTracker.push({
               type: shareType,
               status: "success",
-              amount,
+              amount: shareAmount,
               address,
               payment,
             });
@@ -581,7 +581,7 @@ function createZapDependencies({ creatorEntry, platformEntry, shares, shareTrack
             shareTracker.push({
               type: shareType,
               status: "error",
-              amount,
+              amount: shareAmount,
               address,
               error,
             });
@@ -590,7 +590,7 @@ function createZapDependencies({ creatorEntry, platformEntry, shares, shareTrack
             "wallet.sendPayment",
             {
               shareType,
-              amount,
+              amount: shareAmount,
               address,
               tracker: shareTracker,
               context: { shares },


### PR DESCRIPTION
## Summary
- rename the zap share amount variable in the channel profile wallet adapter to avoid leaking into the global scope
- ensure share tracker logging references the renamed share amount so ReferenceErrors are not thrown during zap attempts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2b28c6074832b83032b36dbfcc4d2