### PR TITLE
Fix zap dialog positioning and gating

### DIFF
--- a/components/video-modal.html
+++ b/components/video-modal.html
@@ -35,18 +35,124 @@
                 class="icon-image"
               />
             </button>
-            <button
-              id="modalZapBtn"
-              type="button"
-              class="icon-button"
-              aria-label="Send a zap"
-            >
-              <img
-                src="assets/svg/lightning-bolt.svg"
-                alt="Zap"
-                class="icon-image"
-              />
-            </button>
+            <div class="relative" data-modal-zap-wrapper>
+              <button
+                id="modalZapBtn"
+                type="button"
+                class="icon-button"
+                aria-label="Send a zap"
+                aria-haspopup="dialog"
+                aria-expanded="false"
+                aria-controls="modalZapDialog"
+              >
+                <img
+                  src="assets/svg/lightning-bolt.svg"
+                  alt="Zap"
+                  class="icon-image"
+                />
+              </button>
+              <div
+                id="modalZapDialog"
+                class="zap-popover hidden"
+                role="dialog"
+                aria-hidden="true"
+              >
+                <div
+                  class="zap-popover__content w-72 max-w-[calc(100vw-2rem)] rounded-lg bg-gray-900/95 p-4 shadow-lg backdrop-blur"
+                >
+                  <div class="mb-3 flex items-center justify-between gap-4">
+                    <h3
+                      class="text-xs font-semibold uppercase tracking-wide text-gray-300"
+                    >
+                      Send a zap
+                    </h3>
+                    <button
+                      type="button"
+                      id="modalZapCloseBtn"
+                      class="text-gray-400 transition-colors hover:text-gray-200"
+                      aria-label="Close zap dialog"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                  <p
+                    id="modalZapWalletPrompt"
+                    class="mb-3 hidden text-sm text-gray-200"
+                    aria-hidden="true"
+                  >
+                    Connect a wallet in
+                    <button
+                      type="button"
+                      id="modalZapWalletLink"
+                      class="font-semibold text-blue-300 underline decoration-dotted transition-colors hover:text-blue-200"
+                    >
+                      Wallet Connect settings
+                    </button>
+                    to send zaps.
+                  </p>
+                  <form id="modalZapForm" class="space-y-3">
+                    <div>
+                      <label
+                        for="modalZapAmountInput"
+                        class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-300"
+                      >
+                        Zap amount (sats)
+                      </label>
+                      <input
+                        id="modalZapAmountInput"
+                        type="number"
+                        min="1"
+                        step="1"
+                        inputmode="numeric"
+                        class="w-full rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                        placeholder="Enter sats"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        for="modalZapCommentInput"
+                        class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-300"
+                      >
+                        Comment (optional)
+                      </label>
+                      <textarea
+                        id="modalZapCommentInput"
+                        rows="2"
+                        maxlength="280"
+                        class="w-full resize-y rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                        placeholder="Include a note with your zap"
+                      ></textarea>
+                    </div>
+                    <p
+                      id="modalZapSplitSummary"
+                      class="text-sm text-gray-300"
+                      aria-live="polite"
+                    >
+                      Enter an amount to view the split.
+                    </p>
+                    <p
+                      id="modalZapStatus"
+                      class="text-xs text-gray-400"
+                      role="status"
+                      aria-live="polite"
+                    ></p>
+                    <ul
+                      id="modalZapReceipts"
+                      class="space-y-2 text-xs text-gray-300"
+                    ></ul>
+                    <div class="flex items-center justify-end gap-2">
+                      <button
+                        type="submit"
+                        id="modalZapSendBtn"
+                        class="rounded bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900"
+                      >
+                        Send zap
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
             <button id="shareBtn" class="icon-button">
               <img
                 src="assets/svg/share-video.svg"
@@ -165,89 +271,6 @@
           <p id="videoDescription" class="text-gray-300 whitespace-pre-wrap">
             No description available.
           </p>
-        </div>
-
-        <!-- Zap dialog -->
-        <div id="modalZapDialog" class="hidden mt-4" aria-hidden="true">
-          <div
-            class="w-full rounded-lg bg-gray-900 bg-opacity-70 p-4 shadow-lg backdrop-blur"
-          >
-            <div class="flex items-center justify-between mb-3">
-              <h3
-                class="text-xs font-semibold uppercase tracking-wide text-gray-300"
-              >
-                Send a zap
-              </h3>
-              <button
-                type="button"
-                id="modalZapCloseBtn"
-                class="text-gray-400 hover:text-gray-200 transition-colors"
-                aria-label="Close zap dialog"
-              >
-                ✕
-              </button>
-            </div>
-            <form id="modalZapForm" class="space-y-3">
-              <div>
-                <label
-                  for="modalZapAmountInput"
-                  class="block text-xs font-semibold uppercase tracking-wide text-gray-300 mb-2"
-                >
-                  Zap amount (sats)
-                </label>
-                <input
-                  id="modalZapAmountInput"
-                  type="number"
-                  min="1"
-                  step="1"
-                  inputmode="numeric"
-                  class="w-full rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
-                  placeholder="Enter sats"
-                />
-              </div>
-              <div>
-                <label
-                  for="modalZapCommentInput"
-                  class="block text-xs font-semibold uppercase tracking-wide text-gray-300 mb-2"
-                >
-                  Comment (optional)
-                </label>
-                <textarea
-                  id="modalZapCommentInput"
-                  rows="2"
-                  maxlength="280"
-                  class="w-full resize-y rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
-                  placeholder="Include a note with your zap"
-                ></textarea>
-              </div>
-              <p
-                id="modalZapSplitSummary"
-                class="text-sm text-gray-300"
-                aria-live="polite"
-              >
-                Enter an amount to view the split.
-              </p>
-              <p
-                id="modalZapStatus"
-                class="text-xs text-gray-400"
-                role="status"
-                aria-live="polite"
-              ></p>
-              <ul
-                id="modalZapReceipts"
-                class="space-y-2 text-xs text-gray-300"
-              ></ul>
-              <div class="flex items-center justify-end gap-2">
-                <button
-                  type="submit"
-                  id="modalZapSendBtn"
-                  class="rounded bg-blue-500 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-gray-900"
-                >
-                  Send zap
-                </button>
-              </div>
-            </form>
-          </div>
         </div>
 
         <!-- Torrent stats -->

--- a/css/style.css
+++ b/css/style.css
@@ -1016,6 +1016,19 @@ body.modal-open #app {
   flex-wrap: nowrap;
 }
 
+.zap-popover {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  z-index: 80;
+  width: max-content;
+}
+
+.zap-popover__content {
+  width: 18rem;
+  max-width: calc(100vw - 2rem);
+}
+
 .modal-actions__overflow {
   position: relative;
   overflow: visible;

--- a/js/app.js
+++ b/js/app.js
@@ -198,6 +198,7 @@ class Application {
     this.boundVideoModalShareHandler = null;
     this.boundVideoModalCreatorHandler = null;
     this.boundVideoModalZapHandler = null;
+    this.boundVideoModalZapWalletHandler = null;
     this.videoListViewPlaybackHandler = null;
     this.videoListViewEditHandler = null;
     this.videoListViewRevertHandler = null;
@@ -528,6 +529,15 @@ class Application {
     this.videoModal.addEventListener(
       "zap:comment-change",
       this.boundVideoModalZapCommentHandler
+    );
+    this.boundVideoModalZapWalletHandler = () => {
+      if (typeof this.openWalletPane === "function") {
+        this.openWalletPane();
+      }
+    };
+    this.videoModal.addEventListener(
+      "zap:wallet-link",
+      this.boundVideoModalZapWalletHandler
     );
 
     // Hide/Show Subscriptions Link
@@ -4512,6 +4522,17 @@ class Application {
     return cached ? { ...cached } : createDefaultNwcSettings();
   }
 
+  hasActiveWalletConnection() {
+    const settings = this.getActiveNwcSettings();
+    const candidate =
+      typeof settings?.nwcUri === "string" ? settings.nwcUri.trim() : "";
+    return candidate.length > 0;
+  }
+
+  isUserLoggedIn() {
+    return Boolean(this.normalizeHexPubkey(this.pubkey));
+  }
+
   async updateActiveNwcSettings(partial = {}) {
     const normalized = this.normalizeHexPubkey(this.pubkey);
     if (!normalized) {
@@ -5726,8 +5747,12 @@ class Application {
   }
 
   setModalZapVisibility(visible) {
+    const lightningVisible = !!visible;
+    const shouldShow = lightningVisible && this.isUserLoggedIn();
+    const hasWallet = this.hasActiveWalletConnection();
     if (this.videoModal) {
-      this.videoModal.setZapVisibility(visible);
+      this.videoModal.setZapVisibility(shouldShow);
+      this.videoModal.setWalletPromptVisible(shouldShow && !hasWallet);
     }
   }
 
@@ -9478,6 +9503,13 @@ class Application {
           this.boundVideoModalZapCommentHandler
         );
         this.boundVideoModalZapCommentHandler = null;
+      }
+      if (this.boundVideoModalZapWalletHandler) {
+        this.videoModal.removeEventListener(
+          "zap:wallet-link",
+          this.boundVideoModalZapWalletHandler
+        );
+        this.boundVideoModalZapWalletHandler = null;
       }
       if (typeof this.videoModal.destroy === "function") {
         try {

--- a/js/ui/components/VideoModal.js
+++ b/js/ui/components/VideoModal.js
@@ -54,6 +54,8 @@ export class VideoModal {
     this.modalZapReceipts = null;
     this.modalZapSendBtn = null;
     this.modalZapCloseBtn = null;
+    this.modalZapWalletPrompt = null;
+    this.modalZapWalletLink = null;
     this.modalZapDialogOpen = false;
     this.modalZapPending = false;
 
@@ -208,6 +210,10 @@ export class VideoModal {
       playerModal.querySelector("#modalZapSendBtn") || null;
     this.modalZapCloseBtn =
       playerModal.querySelector("#modalZapCloseBtn") || null;
+    this.modalZapWalletPrompt =
+      playerModal.querySelector("#modalZapWalletPrompt") || null;
+    this.modalZapWalletLink =
+      playerModal.querySelector("#modalZapWalletLink") || null;
 
     const closeButton = playerModal.querySelector("#closeModal");
     if (closeButton) {
@@ -304,6 +310,13 @@ export class VideoModal {
       this.modalZapCloseBtn.addEventListener("click", (event) => {
         event?.preventDefault?.();
         this.closeZapDialog();
+      });
+    }
+
+    if (this.modalZapWalletLink) {
+      this.modalZapWalletLink.addEventListener("click", (event) => {
+        event?.preventDefault?.();
+        this.dispatch("zap:wallet-link", { video: this.activeVideo });
       });
     }
 
@@ -539,6 +552,7 @@ export class VideoModal {
       this.modalZapBtn.disabled = disableButton;
       this.modalZapBtn.setAttribute("aria-disabled", (!shouldShow).toString());
       this.modalZapBtn.setAttribute("aria-hidden", (!shouldShow).toString());
+      this.modalZapBtn.setAttribute("aria-expanded", "false");
       if (shouldShow) {
         this.modalZapBtn.removeAttribute("tabindex");
       } else {
@@ -558,6 +572,18 @@ export class VideoModal {
     }
   }
 
+  setWalletPromptVisible(visible) {
+    if (!this.modalZapWalletPrompt) {
+      return;
+    }
+    const shouldShow = !!visible;
+    this.modalZapWalletPrompt.classList.toggle("hidden", !shouldShow);
+    this.modalZapWalletPrompt.setAttribute(
+      "aria-hidden",
+      (!shouldShow).toString()
+    );
+  }
+
   openZapDialog() {
     if (!this.modalZapDialog) {
       return;
@@ -565,6 +591,9 @@ export class VideoModal {
     this.modalZapDialog.classList.remove("hidden");
     this.modalZapDialogOpen = true;
     this.modalZapDialog.setAttribute("aria-hidden", "false");
+    if (this.modalZapBtn) {
+      this.modalZapBtn.setAttribute("aria-expanded", "true");
+    }
     this.focusZapAmount();
   }
 
@@ -576,6 +605,9 @@ export class VideoModal {
       this.modalZapDialog.classList.add("hidden");
       this.modalZapDialog.setAttribute("aria-hidden", "true");
       this.modalZapDialogOpen = false;
+      if (this.modalZapBtn) {
+        this.modalZapBtn.setAttribute("aria-expanded", "false");
+      }
       if (!silent) {
         this.dispatch("zap:close", { video: this.activeVideo });
       }

--- a/views/channel-profile.html
+++ b/views/channel-profile.html
@@ -29,18 +29,96 @@
       </div>
       <div class="flex flex-col items-end gap-3 self-start sm:self-end">
         <div class="flex items-center gap-2">
-          <button
-            id="zapButton"
-            type="button"
-            class="icon-button"
-            aria-label="Send a zap"
-          >
-            <img
-              src="assets/svg/lightning-bolt.svg"
-              alt="Zap"
-              class="icon-image"
-            />
-          </button>
+          <div class="relative" data-channel-zap-wrapper>
+            <button
+              id="zapButton"
+              type="button"
+              class="icon-button"
+              aria-label="Open zap dialog"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="zapControls"
+            >
+              <img
+                src="assets/svg/lightning-bolt.svg"
+                alt="Zap"
+                class="icon-image"
+              />
+            </button>
+            <div
+              id="zapControls"
+              class="zap-popover hidden"
+              role="dialog"
+              aria-hidden="true"
+              aria-label="Channel zap dialog"
+            >
+              <div
+                class="zap-popover__content w-72 max-w-[calc(100vw-2rem)] rounded-lg bg-gray-900/95 p-4 shadow-lg backdrop-blur"
+              >
+                <div class="mb-3 flex items-center justify-between gap-4">
+                  <h3
+                    class="text-xs font-semibold uppercase tracking-wide text-gray-300"
+                  >
+                    Send a zap
+                  </h3>
+                  <button
+                    type="button"
+                    id="zapCloseBtn"
+                    class="text-gray-400 transition-colors hover:text-gray-200"
+                    aria-label="Close zap dialog"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <p
+                  id="zapWalletPrompt"
+                  class="mb-3 hidden text-sm text-gray-200"
+                  aria-hidden="true"
+                >
+                  Connect a wallet in
+                  <button
+                    type="button"
+                    id="zapWalletLink"
+                    class="font-semibold text-blue-300 underline decoration-dotted transition-colors hover:text-blue-200"
+                  >
+                    Wallet Connect settings
+                  </button>
+                  to send zaps.
+                </p>
+                <label
+                  for="zapAmountInput"
+                  id="zapAmountLabel"
+                  class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-300"
+                >
+                  Zap amount (sats)
+                </label>
+                <input
+                  id="zapAmountInput"
+                  type="number"
+                  min="1"
+                  step="1"
+                  inputmode="numeric"
+                  class="w-full rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  placeholder="Enter sats"
+                  aria-labelledby="zapAmountLabel"
+                />
+                <p
+                  id="zapSplitSummary"
+                  class="mt-3 text-sm text-gray-300"
+                  aria-live="polite"
+                >
+                  Enter an amount to view the split.
+                </p>
+                <p
+                  id="zapStatus"
+                  class="mt-2 text-xs text-gray-400"
+                  role="status"
+                  aria-live="polite"
+                ></p>
+                <ul id="zapReceipts" class="mt-3 space-y-2 text-xs text-gray-300"></ul>
+              </div>
+            </div>
+          </div>
           <button
             id="channelShareBtn"
             type="button"
@@ -106,36 +184,6 @@
                 </button>
               </div>
             </div>
-          </div>
-        </div>
-        <div id="zapControls" class="hidden w-full max-w-xs sm:max-w-sm">
-          <div class="w-full rounded-lg bg-gray-900 bg-opacity-70 p-4 shadow-lg backdrop-blur">
-            <label for="zapAmountInput" class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-300">
-              Zap amount (sats)
-            </label>
-            <input
-              id="zapAmountInput"
-              type="number"
-              min="1"
-              step="1"
-              inputmode="numeric"
-              class="w-full rounded border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
-              placeholder="Enter sats"
-            />
-            <p
-              id="zapSplitSummary"
-              class="mt-3 text-sm text-gray-300"
-              aria-live="polite"
-            >
-              Enter an amount to view the split.
-            </p>
-            <p
-              id="zapStatus"
-              class="mt-2 text-xs text-gray-400"
-              role="status"
-              aria-live="polite"
-            ></p>
-            <ul id="zapReceipts" class="mt-3 space-y-2 text-xs text-gray-300"></ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- anchor the video modal zap dialog to the lightning button and surface a Wallet Connect helper link
- gate channel zap controls behind login, render them as a popover, and prompt wallet-less users to open Wallet Connect settings
- add shared popover styling and update zap visibility logic to respect login and wallet status

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68e2b70ebaa0832b934332a1fdcddcc4