### PR TITLE
Convert NWC client payment amount to msats

### DIFF
--- a/tests/nwc-client.test.mjs
+++ b/tests/nwc-client.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+
+if (typeof globalThis.window === "undefined") {
+  globalThis.window = {};
+}
+
+const { __TESTING__ } = await import("../js/payments/nwcClient.js");
+const { buildPayInvoiceParams } = __TESTING__;
+
+await (async () => {
+  const params = buildPayInvoiceParams({
+    invoice: "bolt11-invoice",
+    amountSats: 123,
+    zapRequest: "zap-request-json",
+  });
+
+  assert.equal(params.invoice, "bolt11-invoice");
+  assert.equal(params.amount, 123_000);
+  assert.equal(params.zap_request, "zap-request-json");
+})();
+
+await (async () => {
+  const params = buildPayInvoiceParams({
+    invoice: "bolt11-invoice",
+    amountSats: 0,
+    zapRequest: null,
+  });
+
+  assert.equal(params.invoice, "bolt11-invoice");
+  assert.ok(!("amount" in params));
+  assert.ok(!("zap_request" in params));
+})();
+
+await (async () => {
+  const params = buildPayInvoiceParams({
+    invoice: "bolt11-invoice",
+    amountSats: 42.7,
+  });
+
+  assert.equal(params.amount, 43_000);
+})();
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- update the NWC client to convert provided satoshi amounts to millisatoshis before dispatching pay_invoice requests
- expose a helper for building pay_invoice params to facilitate testing and add coverage for the msat conversion logic

## Testing
- node tests/nwc-client.test.mjs
- node tests/zap-split.test.mjs
- node tests/video-modal-zap.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e2ff2fb180832ba804768de828d233