### PR TITLE
Handle multi-relay NWC URIs

### DIFF
--- a/tests/nwc-client.test.mjs
+++ b/tests/nwc-client.test.mjs
@@ -4,8 +4,9 @@ if (typeof globalThis.window === "undefined") {
   globalThis.window = {};
 }
 
-const { __TESTING__ } = await import("../js/payments/nwcClient.js");
-const { buildPayInvoiceParams } = __TESTING__;
+const nwcModule = await import("../js/payments/nwcClient.js");
+const { __TESTING__, resetWalletClient } = nwcModule;
+const { buildPayInvoiceParams, ensureActiveState, parseNwcUri, getActiveState } = __TESTING__;
 
 await (async () => {
   const params = buildPayInvoiceParams({
@@ -38,6 +39,43 @@ await (async () => {
   });
 
   assert.equal(params.amount, 43_000);
+})();
+
+await (async () => {
+  resetWalletClient();
+
+  window.NostrTools = {
+    getPublicKey() {
+      return "c".repeat(64);
+    },
+  };
+
+  const walletPubkey = "b".repeat(64);
+  const secretKey = "a".repeat(64);
+  const relays = ["wss://relay.one.example", "wss://relay.two.example"];
+  const lud16 = "user@example.com";
+  const uri =
+    `nostr+walletconnect://${walletPubkey}` +
+    `?relay=${encodeURIComponent(relays[0])}` +
+    `&relay=${encodeURIComponent(relays[1])}` +
+    `&secret=${secretKey}` +
+    `&lud16=${encodeURIComponent(lud16)}`;
+
+  const context = ensureActiveState({ nwcUri: uri });
+
+  assert.deepEqual(context.relayUrls, relays);
+  assert.equal(context.relayUrl, relays[0]);
+  assert.equal(context.uri.split("?")[0], `nostr+walletconnect://${walletPubkey}`);
+
+  const state = getActiveState();
+  assert.ok(state?.settings?.nwcUri);
+
+  const reparsed = parseNwcUri(state.settings.nwcUri);
+  assert.deepEqual(reparsed.relays, relays);
+  assert.equal(reparsed.secretKey, secretKey);
+  assert.equal(reparsed.queryParams.lud16, lud16);
+
+  resetWalletClient();
 })();
 
 process.exit(0);


### PR DESCRIPTION
## Summary
- Parse NWC URIs into structured data that preserves multiple relays and auxiliary parameters
- Update the wallet client state to retain relay arrays and normalized parameters
- Add regression coverage to ensure multi-relay URIs with optional fields round-trip correctly

## Testing
- node tests/nwc-client.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68e3027e4264832bbd431c5c3290f893