### PR TITLE
Ensure platform zap lookups await Nostr pool

### DIFF
--- a/js/payments/platformAddress.js
+++ b/js/payments/platformAddress.js
@@ -88,13 +88,28 @@ async function fetchAdminMetadata(adminPubkey) {
     return null;
   }
 
-  if (!nostrClient?.pool || !Array.isArray(nostrClient?.relays)) {
+  let pool;
+  try {
+    pool = await nostrClient.ensurePool();
+  } catch (error) {
+    console.warn("[platformAddress] Failed to initialize Nostr pool", error);
+    return null;
+  }
+
+  if (!pool) {
+    return null;
+  }
+
+  const relayUrls = Array.isArray(nostrClient?.relays)
+    ? nostrClient.relays
+    : [];
+  if (relayUrls.length === 0) {
     console.warn("[platformAddress] Nostr client is not ready.");
     return null;
   }
 
   try {
-    const events = await nostrClient.pool.list(nostrClient.relays, [
+    const events = await pool.list(relayUrls, [
       { kinds: [0], authors: [adminPubkey], limit: 1 },
     ]);
 


### PR DESCRIPTION
## Summary
- add an async-safe `ensurePool` helper on `NostrClient` so SimplePool creation is shared across callers
- use the helper in the platform lightning address fetch to avoid boot-time short circuits
- extend the zap split tests to cover delayed pool readiness via a stubbed `ensurePool`

## Testing
- node tests/zap-split.test.mjs


------
https://chatgpt.com/codex/tasks/task_b_68e328f4c658832bb5f4d2e39e6973b3