### PR TITLE
Document nostr tools bootstrap ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,7 @@
     </div>
 
     <!-- Additional Scripts -->
+    <!-- Bootstraps nostr-tools before other modules rely on nostrToolsReady -->
     <script type="module" src="js/nostrToolsBootstrap.js"></script>
     <script type="module" src="js/config.js"></script>
     <script type="module" src="js/lists.js"></script>


### PR DESCRIPTION
## Summary
- annotate index.html to call out that the nostr-tools bootstrap module must load before any scripts that rely on `nostrToolsReady`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3c863d088832bab208080e6f0a8ee