### PR TITLE
Handle alternate SimplePool exports

### DIFF
--- a/js/nostr.js
+++ b/js/nostr.js
@@ -4292,7 +4292,14 @@ class NostrClient {
     }
 
     const tools = await ensureNostrTools();
-    const SimplePool = tools?.SimplePool;
+    const SimplePool =
+      typeof tools?.SimplePool === "function"
+        ? tools.SimplePool
+        : typeof tools?.pool?.SimplePool === "function"
+        ? tools.pool.SimplePool
+        : typeof tools?.SimplePool?.SimplePool === "function"
+        ? tools.SimplePool.SimplePool
+        : null;
     if (typeof SimplePool !== "function") {
       const error = new Error("NostrTools SimplePool is unavailable.");
       error.code = "nostr-simplepool-unavailable";


### PR DESCRIPTION
## Summary
- allow the Nostr client to detect SimplePool when nostr-tools nests it under `pool`
- keep existing error handling when the helper is still unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e3d084b2dc832b805c263553a91aad