### PR TITLE
Fix main layout width when toggling sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1799,7 +1799,10 @@ body.sidebar-open #sidebarOverlay {
 
   #app {
     margin-left: var(--sidebar-width);
-    transition: margin-left 200ms ease;
+    width: calc(100vw - var(--sidebar-width));
+    max-width: calc(100vw - var(--sidebar-width));
+    box-sizing: border-box;
+    transition: margin-left 200ms ease, width 200ms ease;
   }
 
   body.sidebar-collapsed,


### PR DESCRIPTION
## Summary
- ensure the desktop app shell width uses the sidebar width variable so the main content resizes with the sidebar state
- include border-box sizing to prevent padding from reintroducing horizontal overflow during transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e45b8466a4832b95a84c93674cb0b2