### PR TITLE
Fix main layout width when toggling sidebar

### DIFF
--- a/components/iframe_forms/iframe-application-form.html
+++ b/components/iframe_forms/iframe-application-form.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>bitvid Whitelist Application Form</title>
     <!-- Link to your main stylesheet -->
-    <link rel="stylesheet" href="../../css/style.css?v=2024.10.22" />
+    <link rel="stylesheet" href="../../css/style.css?v=2024.10.23" />
     <style>
       /* Override for form page to match modal field styling */
 

--- a/components/iframe_forms/iframe-bug-fix-form.html
+++ b/components/iframe_forms/iframe-bug-fix-form.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>bitvid Bug Report Form</title>
     <!-- Link to your main stylesheet -->
-    <link rel="stylesheet" href="../../css/style.css?v=2024.10.22" />
+    <link rel="stylesheet" href="../../css/style.css?v=2024.10.23" />
     <style>
       /* Override for form page to match modal field styling */
 

--- a/components/iframe_forms/iframe-content-appeals-form.html
+++ b/components/iframe_forms/iframe-content-appeals-form.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>bitvid Content Appeals Form</title>
     <!-- Link to your main stylesheet -->
-    <link rel="stylesheet" href="../../css/style.css?v=2024.10.22" />
+    <link rel="stylesheet" href="../../css/style.css?v=2024.10.23" />
     <style>
       /* Override for form page to match modal field styling */
 

--- a/components/iframe_forms/iframe-feedback-form.html
+++ b/components/iframe_forms/iframe-feedback-form.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>bitvid General Feedback Form</title>
     <!-- Link to your main stylesheet -->
-    <link rel="stylesheet" href="../../css/style.css?v=2024.10.22" />
+    <link rel="stylesheet" href="../../css/style.css?v=2024.10.23" />
     <style>
       /* Override for form page to match modal field styling */
 

--- a/components/iframe_forms/iframe-request-form.html
+++ b/components/iframe_forms/iframe-request-form.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>bitvid Feature Request Form</title>
     <!-- Link to your main stylesheet -->
-    <link rel="stylesheet" href="../../css/style.css?v=2024.10.22" />
+    <link rel="stylesheet" href="../../css/style.css?v=2024.10.23" />
     <style>
       /* Override for form page to match modal field styling */
 

--- a/config/asset-version.js
+++ b/config/asset-version.js
@@ -1,1 +1,1 @@
-export const ASSET_VERSION = "2024.10.22";
+export const ASSET_VERSION = "2024.10.23";

--- a/css/style.css
+++ b/css/style.css
@@ -1799,7 +1799,10 @@ body.sidebar-open #sidebarOverlay {
 
   #app {
     margin-left: var(--sidebar-width);
-    transition: margin-left 200ms ease;
+    width: calc(100vw - var(--sidebar-width));
+    max-width: calc(100vw - var(--sidebar-width));
+    box-sizing: border-box;
+    transition: margin-left 200ms ease, width 200ms ease;
   }
 
   body.sidebar-collapsed,

--- a/index.html
+++ b/index.html
@@ -50,10 +50,10 @@
       so browsers pick up the latest sidebar markup and styling without
       hard-refreshing around CDN caches.
     -->
-    <script src="js/tracking.js?v=2024.10.22" defer></script>
-    <link href="css/tailwind.generated.css?v=2024.10.22" rel="stylesheet" />
-    <link href="css/style.css?v=2024.10.22" rel="stylesheet" />
-    <link href="css/markdown.css?v=2024.10.22" rel="stylesheet" />
+    <script src="js/tracking.js?v=2024.10.23" defer></script>
+    <link href="css/tailwind.generated.css?v=2024.10.23" rel="stylesheet" />
+    <link href="css/style.css?v=2024.10.23" rel="stylesheet" />
+    <link href="css/markdown.css?v=2024.10.23" rel="stylesheet" />
   </head>
   <body class="sidebar-collapsed">
     <!--
@@ -211,16 +211,16 @@
 
     <!-- Additional Scripts -->
     <!-- Bootstraps nostr-tools before other modules rely on nostrToolsReady -->
-      <script type="module" src="js/nostrToolsBootstrap.js?v=2024.10.22"></script>
-      <script type="module" src="js/config.js?v=2024.10.22"></script>
-      <script type="module" src="js/lists.js?v=2024.10.22"></script>
-      <script type="module" src="js/accessControl.js?v=2024.10.22"></script>
-      <script type="module" src="js/webtorrent.js?v=2024.10.22"></script>
-      <script type="module" src="js/nostr.js?v=2024.10.22"></script>
-    <script type="module" src="js/viewManager.js?v=2024.10.22"></script>
-    <script type="module" src="js/bootstrap.js?v=2024.10.22"></script>
-    <script type="module" src="js/disclaimer.js?v=2024.10.22"></script>
-    <script type="module" src="js/index.js?v=2024.10.22"></script>
+      <script type="module" src="js/nostrToolsBootstrap.js?v=2024.10.23"></script>
+      <script type="module" src="js/config.js?v=2024.10.23"></script>
+      <script type="module" src="js/lists.js?v=2024.10.23"></script>
+      <script type="module" src="js/accessControl.js?v=2024.10.23"></script>
+      <script type="module" src="js/webtorrent.js?v=2024.10.23"></script>
+      <script type="module" src="js/nostr.js?v=2024.10.23"></script>
+    <script type="module" src="js/viewManager.js?v=2024.10.23"></script>
+    <script type="module" src="js/bootstrap.js?v=2024.10.23"></script>
+    <script type="module" src="js/disclaimer.js?v=2024.10.23"></script>
+    <script type="module" src="js/index.js?v=2024.10.23"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- ensure the desktop app shell width uses the sidebar width variable so the main content resizes with the sidebar state
- include border-box sizing to prevent padding from reintroducing horizontal overflow during transitions
- bump the asset version and cache-busting query strings so the updated sidebar styles ship to production clients

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e45b8466a4832b95a84c93674cb0b2