### PR TITLE
Rely on ProfileModalController service fallbacks

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1296,22 +1296,12 @@ class Application {
           },
           onRequestSwitchProfile: (payload) =>
             this.handleProfileSwitchRequest(payload),
-          onRelayOperation: (payload) =>
-            this.handleProfileRelayOperation(payload),
-          onRelayModeToggle: (payload) =>
-            this.handleProfileRelayModeToggle(payload),
-          onRelayRestore: (payload) =>
-            this.handleProfileRelayRestore(payload),
-          onBlocklistMutation: (payload) =>
-            this.handleProfileBlocklistMutation(payload),
           onWalletPersist: (payload) =>
             this.handleProfileWalletPersist(payload),
           onWalletTestRequest: (payload) =>
             this.handleProfileWalletTest(payload),
           onWalletDisconnectRequest: (payload) =>
             this.handleProfileWalletDisconnect(payload),
-          onAdminMutation: (payload) =>
-            this.handleProfileAdminMutation(payload),
           onAdminNotifyError: (payload) =>
             this.handleProfileAdminNotifyError(payload),
           onHistoryReady: (payload) =>
@@ -2373,129 +2363,6 @@ class Application {
     return true;
   }
 
-  async handleProfileRelayOperation({
-    action,
-    url,
-    activePubkey,
-    skipPublishIfUnchanged = true,
-  } = {}) {
-    const context = {
-      ok: false,
-      changed: false,
-      reason: null,
-      error: null,
-      publishResult: null,
-      operationResult: null,
-    };
-
-    if (!activePubkey) {
-      context.reason = "no-active-pubkey";
-      return context;
-    }
-
-    const previous = this.relayManager.snapshot();
-
-    const runOperation = () => {
-      switch (action) {
-        case "add":
-          return this.relayManager.addRelay(url);
-        case "remove":
-          return this.relayManager.removeRelay(url);
-        case "restore":
-          return this.relayManager.restoreDefaults();
-        case "mode-toggle":
-          return this.relayManager.cycleRelayMode(url);
-        default:
-          throw Object.assign(new Error("Unknown relay operation."), {
-            code: "invalid-operation",
-          });
-      }
-    };
-
-    let operationResult;
-    try {
-      operationResult = runOperation();
-      context.operationResult = operationResult;
-    } catch (error) {
-      context.error = error;
-      context.reason = error?.code || "operation-error";
-      return context;
-    }
-
-    context.changed = Boolean(operationResult?.changed);
-    if (!context.changed && skipPublishIfUnchanged) {
-      context.reason = operationResult?.reason || "unchanged";
-      return context;
-    }
-
-    try {
-      const publishResult = await this.relayManager.publishRelayList(activePubkey);
-      if (!publishResult?.ok) {
-        throw new Error("No relays accepted the update.");
-      }
-      context.ok = true;
-      context.publishResult = publishResult;
-      return context;
-    } catch (error) {
-      this.relayManager.setEntries(previous, { allowEmpty: false });
-      context.error = error;
-      context.reason = error?.code || "publish-failed";
-      return context;
-    }
-  }
-
-  handleProfileRelayModeToggle() {
-    return null;
-  }
-
-  handleProfileRelayRestore() {
-    return null;
-  }
-
-  async handleProfileBlocklistMutation({ action, actorHex, targetHex } = {}) {
-    const context = { ok: false, reason: null, error: null };
-    if (!actorHex || !targetHex) {
-      context.reason = "invalid-target";
-      return context;
-    }
-
-    try {
-      await userBlocks.ensureLoaded(actorHex);
-      const isBlocked = userBlocks.isBlocked(targetHex);
-
-      if (action === "add") {
-        if (isBlocked) {
-          context.reason = "already-blocked";
-          return context;
-        }
-        await userBlocks.addBlock(targetHex, actorHex);
-        context.ok = true;
-        context.reason = "blocked";
-      } else if (action === "remove") {
-        if (!isBlocked) {
-          context.reason = "not-blocked";
-          return context;
-        }
-        await userBlocks.removeBlock(targetHex, actorHex);
-        context.ok = true;
-        context.reason = "unblocked";
-      } else {
-        context.reason = "invalid-action";
-        return context;
-      }
-
-      if (context.ok) {
-        await this.loadVideos(true);
-      }
-
-      return context;
-    } catch (error) {
-      context.error = error;
-      context.reason = error?.code || "service-error";
-      return context;
-    }
-  }
-
   async handleProfileWalletPersist({
     nwcUri,
     defaultZap,
@@ -2525,67 +2392,6 @@ class Application {
 
   async handleProfileWalletDisconnect() {
     return this.updateActiveNwcSettings(createDefaultNwcSettings());
-  }
-
-  async handleProfileAdminMutation(payload = {}) {
-    const action = payload?.action;
-    const resultContext = { ok: false, result: null, error: null };
-
-    try {
-      switch (action) {
-        case "ensure-ready":
-          await accessControl.ensureReady();
-          resultContext.ok = true;
-          break;
-        case "add-moderator":
-          resultContext.result = await accessControl.addModerator(
-            payload.actorNpub,
-            payload.targetNpub,
-          );
-          resultContext.ok = !!resultContext.result?.ok;
-          break;
-        case "remove-moderator":
-          resultContext.result = await accessControl.removeModerator(
-            payload.actorNpub,
-            payload.targetNpub,
-          );
-          resultContext.ok = !!resultContext.result?.ok;
-          break;
-        case "list-mutation":
-          if (payload.listType === "whitelist") {
-            resultContext.result = payload.mode === "add"
-              ? await accessControl.addToWhitelist(
-                  payload.actorNpub,
-                  payload.targetNpub,
-                )
-              : await accessControl.removeFromWhitelist(
-                  payload.actorNpub,
-                  payload.targetNpub,
-                );
-          } else {
-            resultContext.result = payload.mode === "add"
-              ? await accessControl.addToBlacklist(
-                  payload.actorNpub,
-                  payload.targetNpub,
-                )
-              : await accessControl.removeFromBlacklist(
-                  payload.actorNpub,
-                  payload.targetNpub,
-                );
-          }
-          resultContext.ok = !!resultContext.result?.ok;
-          break;
-        default:
-          resultContext.error = Object.assign(
-            new Error("Unknown admin mutation."),
-            { code: "invalid-action" },
-          );
-      }
-    } catch (error) {
-      resultContext.error = error;
-    }
-
-    return resultContext;
   }
 
   handleProfileAdminNotifyError({ error } = {}) {

--- a/js/ui/profileModalController.js
+++ b/js/ui/profileModalController.js
@@ -3125,7 +3125,14 @@ export class ProfileModalController {
       }
 
       if (context.ok) {
-        await this.services.loadVideos();
+        try {
+          await this.services.loadVideos(true);
+        } catch (refreshError) {
+          console.warn(
+            "[ProfileModalController] Failed to refresh videos after blocklist mutation:",
+            refreshError,
+          );
+        }
       }
 
       return context;


### PR DESCRIPTION
## Summary
- remove the redundant Application hooks for relay, blocklist, and admin actions so the profile modal uses its own service fallbacks
- ensure the controller refreshes videos with loadVideos(true) after blocklist mutations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e5583bc9e0832b94d5b0f70670aff5