### PR TITLE
Clarify private listing visibility messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Features
 
 - **Decentralized Sharing**: Video sharing without central servers.
-- **Private Video Listings**: Share encrypted videos for added privacy.
+- **Private Video Listings**: Hide cards from shared grids so only the owner sees them.
 - **Nostr Integration**: Use Nostr keys for login and interaction.
 - **WebTorrent Streaming**: Stream videos directly through torrent technology.
 - **Developer-Friendly**: Open source and customizable for your needs.
@@ -37,7 +37,7 @@ The upload modal enforces **Title + (URL or Magnet)**. Hosted URLs are strongly 
 - **Web seeds (`ws=`)**: HTTPS only. Point to a file root (e.g., `https://cdn.example.com/video/`). Mixed-content (`http://`) hints are rejected just like the modal message explains.
 - **Additional sources (`xs=`)**: Recommend adding an HTTPS `.torrent` link so WebTorrent peers can bootstrap faster.
 - **Trackers**: Bitvid’s browser client only connects to WSS trackers shipped in `js/constants.js`. Do not add UDP or plaintext HTTP trackers to published magnets.
-- **Private toggle**: Encrypts the listing for invited viewers.
+- **Private toggle**: Hides the card from shared grids so only you see it and adds a purple accent so the private state stands out.
 
 ### How playback works
 

--- a/components/upload-modal.html
+++ b/components/upload-modal.html
@@ -725,7 +725,7 @@
                 class="form-checkbox h-5 w-5 text-blue-500"
               />
               <span class="text-sm font-medium text-gray-200"
-                >Private Listing (Encrypt Magnet)</span
+                >Private Listing (Hide from shared grids)</span
               >
             </div>
             -->

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -6,7 +6,7 @@
 - Fix "Dev Mode" publishing "Live Mode" notes—add a flag for dev mode posts.
 - Fix issue with video post set to private.
 - Disable "private video" until I can make it work better.
-- Make "private video" work better using nip-04 encryption for magnet field.
+- Make "private video" work better by hiding cards from shared grids while keeping an owner-only view.
 - Fix slow back button issues on Firefox.
 - Add Amber login support for mobile.
 - Add settings (three dots) button for all videos, not the same as gear menu. Only show delete and edit gear for logged-in users videos.

--- a/content/roadmap/02_bitvid_Enhanced_Migration_of_Note_Spec_Logic.md
+++ b/content/roadmap/02_bitvid_Enhanced_Migration_of_Note_Spec_Logic.md
@@ -31,7 +31,7 @@ This new file could export:
    - `buildNewNote(data, pubkey)`: Takes basic form data and returns a fully structured Nostr note (an object) ready to be signed.
    - `buildEditNote(originalEvent, updatedData)`: Merges old note content with new fields.
    - `softDeleteNote(originalEvent)`: Constructs a note with `deleted = true`.
-   - `encryptMagnet(magnet)`, `decryptMagnet(magnet)`: Real or placeholder encryption functions.
+   - `encryptMagnet(magnet)`, `decryptMagnet(magnet)`: Legacy pass-through helpers kept in case encryption returns; private listings now hide rather than encrypt.
    - `validateNoteContent(content)`: Ensures essential fields (title, magnet, mode, etc.) are present and valid.
 
 Because you’re not implementing Version 3 yet, keep your existing version logic. If you do plan to adopt Version 3 later, the new file is where you’d add or change fields without scattering edits across multiple files.
@@ -53,7 +53,7 @@ export function prepareNewNote(formInput, pubkey) {
   // Combine user inputs with defaults
   const isPrivate = formInput.isPrivate === true;
   const finalMagnet = isPrivate
-    ? encryptMagnet(formInput.magnet)
+    ? encryptMagnet(formInput.magnet) // currently a pass-through; hiding happens at the feed layer
     : formInput.magnet;
 
   return {
@@ -178,7 +178,7 @@ By delegating the actual note-building to `buildEditNote` and `buildDeleteNote`,
 
 6. **Test Thoroughly:**  
    - Create, edit, and delete events to ensure everything behaves the same.  
-   - Confirm that private videos are still encrypted as expected.
+   - Confirm that private videos stay hidden from shared grids as expected.
 
 ---
 
@@ -189,13 +189,13 @@ Below is a small outline showing how you might organize the new file. The actual
 ```js
 // bitvidNoteSpec.js
 
-// A placeholder or real encryption method
+// Legacy placeholder kept for future encryption experiments (currently returns the raw magnet)
 export function encryptMagnet(magnet) {
-  return magnet.split("").reverse().join("");
+  return magnet; // private cards are hidden instead of encrypted
 }
 
 export function decryptMagnet(magnet) {
-  return magnet.split("").reverse().join("");
+  return magnet; // private cards are hidden instead of encrypted
 }
 
 function generateUniqueDTag() {
@@ -206,7 +206,7 @@ function generateUniqueDTag() {
 export function prepareNewNote(formInput, pubkey) {
   const isPrivate = formInput.isPrivate === true;
   const finalMagnet = isPrivate
-    ? encryptMagnet(formInput.magnet)
+    ? encryptMagnet(formInput.magnet) // currently a pass-through; hiding happens at the feed layer
     : formInput.magnet;
 
   return {
@@ -234,7 +234,7 @@ export function prepareNewNote(formInput, pubkey) {
 export function buildEditNote(originalEvent, updatedData) {
   // parse old content
   // combine with new fields
-  // handle old vs new encryption
+  // handle legacy visibility toggles / future encryption experiments
   // return the final event object
 }
 

--- a/content/roadmap/03_bitvid_Enhanced_Nostr_Video_&_Audio_Note_Specification_Version 3.md
+++ b/content/roadmap/03_bitvid_Enhanced_Nostr_Video_&_Audio_Note_Specification_Version 3.md
@@ -43,19 +43,19 @@ A typical event:
 | `videoRootId`                     | String (optional)  | A stable root ID used to link multiple versions (edits) and a delete event together. **Recommended** for overshadow logic. |
 | `version`                         | Integer            | Now set to `3`.                                                                                                            |
 | `deleted`                         | Boolean            | `true` marks the post as “soft deleted.”                                                                                   |
-| `isPrivate`                       | Boolean            | Indicates if `magnet` (and possibly other fields) are encrypted.                                                           |
+| `isPrivate`                       | Boolean            | Indicates the card should stay off shared grids and remain visible only to its owner; payloads stay plaintext. |
 | `title`                           | String             | Display title for the media.                                                                                               |
-| `magnet`                          | String             | Magnet link for primary media (encrypted if `isPrivate = true`).                                                           |
+| `magnet`                          | String             | Magnet link for primary media (still stored in plaintext even when `isPrivate = true`). |
 | `extraMagnets`                    | Array (optional)   | Additional magnet links (e.g., multiple resolutions).                                                                      |
-| `thumbnail`                       | String (optional)  | URL or magnet link to a thumbnail image (encrypted if `isPrivate = true` and `encryptedMeta = true`).                      |
-| `description`                     | String (optional)  | A textual description (encrypted if `isPrivate = true` and `encryptedMeta = true`).                                        |
+| `thumbnail`                       | String (optional)  | URL or magnet link to a thumbnail image. |
+| `description`                     | String (optional)  | A textual description. |
 | `mode`                            | String             | Typically `live` or `dev`.                                                                                                 |
 | `adult`                           | Boolean (optional) | `true` if content is adult-only. Default: `false` or omitted.                                                              |
 | `categories`                      | Array (optional)   | Array of categories, e.g. `["comedy", "music"]`.                                                                           |
 | `language`                        | String (optional)  | Language code (e.g. `"en"`, `"es"`).                                                                                       |
 | `payment`                         | String (optional)  | Monetization field (e.g. a Lightning address).                                                                             |
 | `i18n`                            | Object (optional)  | Internationalization map (e.g. `{"title_en": "...", "description_es": "..."}`).                                            |
-| `encryptedMeta`                   | Boolean (optional) | Indicates if fields like `description` or `thumbnail` are encrypted.                                                       |
+| `encryptedMeta`                   | Boolean (optional) | Legacy flag from earlier encryption experiments; leave `false` unless a future spec revives encrypted metadata. |
 | **Audio/Podcast-Specific Fields** |                    |                                                                                                                            |
 | `contentType`                     | String (optional)  | E.g., `"video"`, `"music"`, `"podcast"`, `"audiobook"`.                                                                    |
 | `albumName`                       | String (optional)  | Name of the album (for music).                                                                                             |
@@ -194,7 +194,7 @@ A typical event:
 ### **8.2 Deletion**
 
 1. **deleted = true**: Mark the item as deleted in the `content` JSON.
-2. **Remove or encrypt** sensitive fields (`magnet`, `description`, etc.).
+2. **Clear** sensitive fields (`magnet`, `description`, etc.) if you do not want them mirrored in older clients.
 3. **videoRootId**: Must remain the same as the original so clients remove/overshadow the old item.
 4. **subscribeVideos** Logic:
    ```js
@@ -217,7 +217,7 @@ A typical event:
 1. **Adult Content**: If `adult = true`, clients typically hide the post unless the user enables adult content in settings.
 2. **Categories**: Provide optional grouping or searching by `categories`.
 3. **Language**: If specified, clients can filter by language.
-4. **Encryption**: If `isPrivate = true`, some fields (e.g., `magnet`) may need client-side decryption.
+4. **Privacy handling**: If `isPrivate = true`, clients should hide the card from shared grids instead of attempting client-side decryption.
 
 ---
 

--- a/docs/nostr-event-schemas.md
+++ b/docs/nostr-event-schemas.md
@@ -59,6 +59,8 @@ read/write split.
 | Admin blacklist (`NOTE_TYPES.ADMIN_BLACKLIST`) | `30000` | `['d', 'bitvid:admin:blacklist']`, repeated `['p', <pubkey>]` entries | Empty content |
 | Admin whitelist (`NOTE_TYPES.ADMIN_WHITELIST`) | `30000` | `['d', 'bitvid:admin:whitelist']`, repeated `['p', <pubkey>]` entries | Empty content |
 
+The `isPrivate` flag in Content Schema v3 marks cards that should stay off shared or public grids. Clients should suppress these events for everyone except the owner, even though the payload stays in clear text for compatibility.
+
 If you introduce a new Nostr feature, add its schema to
 `js/nostrEventSchemas.js` so that the catalogue stays complete and so existing
 builders inherit the same debugging knobs.


### PR DESCRIPTION
## Summary
- clarify the upload modal's private toggle copy so it explains that private listings drop out of shared grids
- refresh README guidance around private listings, including the purple styling cue for owner-only cards
- update event schema and roadmap docs to document that `isPrivate` hides cards rather than encrypting magnets

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e6844165a4832ba588bad256a8f642