### PR TITLE
Add task claiming protocol to prevent duplicate agent work

### DIFF
--- a/docs/agents/prompts/weekly-scheduler.md
+++ b/docs/agents/prompts/weekly-scheduler.md
@@ -49,6 +49,43 @@ Read both `AGENTS.md` and `CLAUDE.md` before executing any task.
 
 ---
 
+## Step 1.5 — Claim the Task (Prevent Duplicate Work)
+
+Before executing the selected task, verify that no other agent is already working on it. Multiple agents may be running simultaneously across different platforms (Claude Code, Codex, Jules), so this check is **mandatory**.
+
+1. **Check for existing claims.** Search for open or draft PRs matching this agent:
+   ```
+   gh pr list --state open --search "<agent-name>"
+   ```
+   For example, if the selected agent is `changelog-agent`, run:
+   ```
+   gh pr list --state open --search "changelog-agent"
+   ```
+   If any matching PR exists (open or draft), this task is **already claimed**.
+
+2. **If already claimed:** Skip to the **next agent** in the roster (following the same alphabetical wrap-around rule from Step 1). Repeat this claim check for the new agent. If you cycle through the entire roster and all agents are claimed, log as `failed` with summary `"All roster tasks currently claimed by other agents"` and stop.
+
+3. **If unclaimed:** Claim the task immediately by creating a draft PR:
+   a. Create your working branch.
+   b. Make a minimal initial commit (e.g., update `CONTEXT.md` with the task scope).
+   c. Push the branch and open a **draft PR**:
+      ```
+      gh pr create --draft \
+        --title "[weekly] <agent-name>: <brief task description>" \
+        --body "Claimed by weekly scheduler at $(date -u +%Y-%m-%dT%H:%M:%SZ). Work in progress."
+      ```
+   d. Verify the draft PR was created successfully before proceeding to Step 2.
+
+4. **Race condition check:** After creating the draft PR, re-check:
+   ```
+   gh pr list --state open --search "<agent-name>"
+   ```
+   If you see another PR for this agent that was created *before* yours (by a different agent instance), close your PR with `gh pr close <your-pr-number>` and skip to the next agent.
+
+**Important:** The draft PR is your lock. Do not skip this step. It prevents other agents on different platforms from picking up the same task.
+
+---
+
 ## Step 2 — Execute the Task
 
 1. Read the selected agent's prompt file from `/docs/agents/prompts/weekly/<filename>`.


### PR DESCRIPTION
## Summary
Introduces a distributed task claiming protocol using draft PRs as locks to prevent multiple agents from working on the same task simultaneously across different platforms (Claude Code, Codex, Jules).

## Key Changes
- **New Step 1.5 in daily-scheduler.md**: Added comprehensive task claiming workflow including:
  - Checking for existing claims via `gh pr list`
  - Creating draft PRs as distributed locks before starting work
  - Race condition detection and handling
  - Clear instructions for skipping to next agent if task is already claimed

- **New Step 1.5 in weekly-scheduler.md**: Identical task claiming protocol adapted for weekly scheduler with `[weekly]` prefix in PR titles

- **New "Task Claiming Protocol" section in AGENTS.md**: Centralized documentation of the draft PR lock mechanism including:
  - Pre-work claim verification steps
  - Draft PR creation workflow with standardized title/body format
  - Race condition handling procedures
  - Conversion to ready-for-review when work is complete
  - Note that scheduler agents must follow this protocol in addition to their CSV-based rotation logic

## Implementation Details
- Draft PRs use standardized titles: `[<zone>] <agent-name>: <brief description>` for daily/weekly schedulers
- Claim verification uses `gh pr list --state open --search` to find matching PRs
- Race condition check re-verifies after PR creation to catch conflicts from concurrent agent instances
- If all roster tasks are claimed, schedulers log as `failed` with appropriate summary message
- The draft PR serves as the authoritative lock visible across all agent execution platforms

https://claude.ai/code/session_01Vnih5ZARbEmnh3EGTDQAXX