### PR TITLE
Fix scheduler task claiming logic and add meta prompts

### DIFF
--- a/docs/agents/prompts/META_PROMPTS.md
+++ b/docs/agents/prompts/META_PROMPTS.md
@@ -1,0 +1,35 @@
+# Bitvid Agent Scheduler Meta Prompts
+
+This file contains the authoritative "Meta Prompts" to be used when triggering the daily and weekly agent schedulers. These prompts ensure that the agent correctly follows the scheduler's logic, including the critical task-claiming step (locking via draft PR) to prevent duplicate work.
+
+---
+
+## Daily Scheduler Meta Prompt
+
+```text
+You are the bitvid daily agent scheduler.
+
+1. Read `AGENTS.md` and `CLAUDE.md` for project rules.
+2. Read `docs/agents/prompts/daily-scheduler.md` and follow its instructions **completely**.
+   - This includes determining the next agent from `docs/agents/AGENT_TASK_LOG.csv`.
+   - **Crucially**, it includes performing the "Claim the Task" check (Step 1.5) to ensure no other agent is working on it.
+   - If the task is already claimed, follow the scheduler's logic to skip to the next agent.
+3. Once a task is claimed and executed according to the scheduler's instructions:
+   - Append the run to `docs/agents/AGENT_TASK_LOG.csv`.
+   - Commit and push your changes.
+```
+
+## Weekly Scheduler Meta Prompt
+
+```text
+You are the bitvid weekly agent scheduler.
+
+1. Read `AGENTS.md` and `CLAUDE.md` for project rules.
+2. Read `docs/agents/prompts/weekly-scheduler.md` and follow its instructions **completely**.
+   - This includes determining the next agent from `docs/agents/WEEKLY_AGENT_TASK_LOG.csv`.
+   - **Crucially**, it includes performing the "Claim the Task" check (Step 1.5) to ensure no other agent is working on it.
+   - If the task is already claimed, follow the scheduler's logic to skip to the next agent.
+3. Once a task is claimed and executed according to the scheduler's instructions:
+   - Append the run to `docs/agents/WEEKLY_AGENT_TASK_LOG.csv`.
+   - Commit and push your changes.
+```

--- a/docs/agents/prompts/daily-scheduler.md
+++ b/docs/agents/prompts/daily-scheduler.md
@@ -60,11 +60,11 @@ Before executing the selected task, verify that no other agent is already workin
 
 1. **Check for existing claims.** Search for open or draft PRs matching this agent:
    ```
-   gh pr list --state open --search "<agent-name>"
+   gh pr list --state open --search "\"[daily] <agent-name>\" in:title"
    ```
    For example, if the selected agent is `audit-agent`, run:
    ```
-   gh pr list --state open --search "audit-agent"
+   gh pr list --state open --search "\"[daily] audit-agent\" in:title"
    ```
    If any matching PR exists (open or draft), this task is **already claimed**.
 
@@ -83,7 +83,7 @@ Before executing the selected task, verify that no other agent is already workin
 
 4. **Race condition check:** After creating the draft PR, re-check:
    ```
-   gh pr list --state open --search "<agent-name>"
+   gh pr list --state open --search "\"[daily] <agent-name>\" in:title"
    ```
    If you see another PR for this agent that was created *before* yours (by a different agent instance), close your PR with `gh pr close <your-pr-number>` and skip to the next agent.
 

--- a/docs/agents/prompts/weekly-scheduler.md
+++ b/docs/agents/prompts/weekly-scheduler.md
@@ -55,11 +55,11 @@ Before executing the selected task, verify that no other agent is already workin
 
 1. **Check for existing claims.** Search for open or draft PRs matching this agent:
    ```
-   gh pr list --state open --search "<agent-name>"
+   gh pr list --state open --search "\"[weekly] <agent-name>\" in:title"
    ```
    For example, if the selected agent is `changelog-agent`, run:
    ```
-   gh pr list --state open --search "changelog-agent"
+   gh pr list --state open --search "\"[weekly] changelog-agent\" in:title"
    ```
    If any matching PR exists (open or draft), this task is **already claimed**.
 
@@ -78,7 +78,7 @@ Before executing the selected task, verify that no other agent is already workin
 
 4. **Race condition check:** After creating the draft PR, re-check:
    ```
-   gh pr list --state open --search "<agent-name>"
+   gh pr list --state open --search "\"[weekly] <agent-name>\" in:title"
    ```
    If you see another PR for this agent that was created *before* yours (by a different agent instance), close your PR with `gh pr close <your-pr-number>` and skip to the next agent.
 


### PR DESCRIPTION
Updated `docs/agents/prompts/daily-scheduler.md` and `docs/agents/prompts/weekly-scheduler.md` to use a more specific `gh pr list` search query (`in:title "[daily] <agent-name>"`) to prevent false positives and race conditions. Added `docs/agents/prompts/META_PROMPTS.md` containing authoritative meta prompts that explicitly instruct agents to follow the scheduler's claim/lock procedure.

---
*PR created automatically by Jules for task [9955232686930365858](https://jules.google.com/task/9955232686930365858) started by @PR0M3TH3AN*