### PR TITLE
[docs] Clarify daily/weekly scheduler PR filter scope in META_PROMPTS

### DIFF
--- a/docs/agents/prompts/META_PROMPTS.md
+++ b/docs/agents/prompts/META_PROMPTS.md
@@ -19,6 +19,8 @@ Follow these steps IN ORDER. Do not skip or reorder any step.
 STEP 0 — PRE-FLIGHT SCAN (do this FIRST, before choosing a task):
   a) Run: curl -s "https://api.github.com/repos/PR0M3TH3AN/bitvid/pulls?state=open&per_page=100" | jq -c '.[] | select(.title | contains("[daily]")) | {number: .number, title: .title, created_at: .created_at, author: .user.login, url: .html_url}'
      Record ALL open daily PRs. Every agent name in those titles is OFF LIMITS.
+     IMPORTANT: this query intentionally filters to titles containing "[daily]". It will NOT list unrelated open PRs.
+     (Optional visibility check) If you need total open PR context, run a second command without the filter.
   b) Read: docs/agents/AGENT_TASK_LOG.csv
      Any agent with status "started" (less than 24h old) is also OFF LIMITS.
   c) Write down your exclusion list before proceeding.
@@ -56,6 +58,8 @@ Follow these steps IN ORDER. Do not skip or reorder any step.
 STEP 0 — PRE-FLIGHT SCAN (do this FIRST, before choosing a task):
   a) Run: curl -s "https://api.github.com/repos/PR0M3TH3AN/bitvid/pulls?state=open&per_page=100" | jq -c '.[] | select(.title | contains("[weekly]")) | {number: .number, title: .title, created_at: .created_at, author: .user.login, url: .html_url}'
      Record ALL open weekly PRs. Every agent name in those titles is OFF LIMITS.
+     IMPORTANT: this query intentionally filters to titles containing "[weekly]". It will NOT list unrelated open PRs.
+     (Optional visibility check) If you need total open PR context, run a second command without the filter.
   b) Read: docs/agents/WEEKLY_AGENT_TASK_LOG.csv
      Any agent with status "started" (less than 24h old) is also OFF LIMITS.
   c) Write down your exclusion list before proceeding.


### PR DESCRIPTION
### Motivation
- Avoid confusion when the Step 0 GitHub query returns only scheduler-scoped PRs by explicitly stating that the `jq` filter limits results to titles containing `"[daily]"` / `"[weekly]"`.

### Description
- Added brief clarifying lines (and an optional unfiltered-visibility note) to `docs/agents/prompts/META_PROMPTS.md` in the STEP 0 pre-flight scan for both the Daily and Weekly scheduler meta prompts.

### Testing
- Verified the change by printing and inspecting the file contents with `sed -n` and `nl -ba`, and confirmed the new explanatory lines appear in `docs/agents/prompts/META_PROMPTS.md` as intended; no additional automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698e74911740832bb0c037f4317e1540)