### PR TITLE
[docs] Enforce sortable race-check metadata in scheduler prompts

### DIFF
--- a/docs/agents/prompts/weekly-scheduler.md
+++ b/docs/agents/prompts/weekly-scheduler.md
@@ -76,7 +76,7 @@ If you arrived here from the meta prompt and already ran these commands and past
 
 Run this command:
 ```bash
-curl -s "https://api.github.com/repos/PR0M3TH3AN/bitvid/pulls?state=open&per_page=100" | jq '{count: length, prs: [.[] | {number, title, draft, created_at, head: {ref: .head.ref}, labels: [.labels[].name]}]}'
+curl -s "https://api.github.com/repos/PR0M3TH3AN/bitvid/pulls?state=open&per_page=100" | jq '{count: length, prs: [.[] | {number, created_at, draft, head: {ref: .head.ref}, agent: ((.head.ref | capture("^agents/weekly/(?<agent>[^/]+)/")?.agent) // (.title | capture("(?<agent>[A-Za-z0-9-]+-agent)")?.agent // null))}] | sort_by(.created_at, .number)}'
 ```
 
 **Paste the complete raw output.** If the command returns nothing or errors, write: `OUTPUT: (empty — no results)`
@@ -175,9 +175,18 @@ You must create a visible claim before doing any work. This claim is a **distrib
 
 After pushing, re-check for competing claims:
 ```bash
-curl -s "https://api.github.com/repos/PR0M3TH3AN/bitvid/pulls?state=open&per_page=100" | jq '{count: length, prs: [.[] | {number, title, draft, created_at, head: {ref: .head.ref}, labels: [.labels[].name]}]}'
+curl -s "https://api.github.com/repos/PR0M3TH3AN/bitvid/pulls?state=open&per_page=100" | jq '{count: length, prs: [.[] | {number, created_at, draft, head: {ref: .head.ref}, agent: ((.head.ref | capture("^agents/weekly/(?<agent>[^/]+)/")?.agent) // (.title | capture("(?<agent>[A-Za-z0-9-]+-agent)")?.agent // null))}] | sort_by(.created_at, .number)}'
 ```
-If you see another PR for this agent that was created *before* yours, abandon your branch and go back to Step 1 to select the next agent.
+Decision logic (must be explicit):
+1. Compare only open/draft PRs whose derived `agent` matches the agent you just claimed.
+2. If another matching PR has an earlier `created_at`, abort this run and pick the next agent.
+3. If `created_at` values are equal or ambiguous, use the lower `number` as the tie-breaker (lower number wins).
+
+Before proceeding, print exactly one race verdict line:
+- `RACE CHECK: won`
+- `RACE CHECK: lost (agent already claimed by PR #<number>)`
+
+If the verdict is lost, abandon your branch and go back to Step 1 to select the next agent.
 
 ### 2c. Log "started" in the task log immediately
 


### PR DESCRIPTION
### Motivation

- Prevent ambiguous scheduler races by requiring a sortable PR metadata projection and explicit decision rules when claiming daily/weekly agent tasks.
- Make preflight/meta guidance consistent so pre-run checks and in-task logic enforce the same race verdict behavior.

### Description

- Updated the PR metadata `jq` projection in `docs/agents/prompts/daily-scheduler.md` and `docs/agents/prompts/weekly-scheduler.md` to return `number`, `created_at`, `draft`, `head.ref` and a derived `agent` field (extracted from `head.ref` with a fallback from `title`) and to sort results with `sort_by(.created_at, .number)` for deterministic ordering.
- Rewrote Step 2b in both scheduler prompts to include explicit decision logic requiring comparison of only same-`agent` open/draft PRs, aborting if a matching PR has earlier `created_at`, and using lower PR `number` as a tie-breaker when timestamps are equal or ambiguous.
- Added a mandatory one-line race verdict requirement printed before proceeding, requiring exactly either `RACE CHECK: won` or `RACE CHECK: lost (agent already claimed by PR #...)`.
- Mirrored the sortable metadata command and the same race-check rule text into `docs/agents/prompts/META_PROMPTS.md` so meta/preflight instructions match the in-task scheduler behavior.

### Testing

- Verified files changed are `docs/agents/prompts/daily-scheduler.md`, `docs/agents/prompts/weekly-scheduler.md`, and `docs/agents/prompts/META_PROMPTS.md` and that the new `jq` projections and decision text appear as expected by running `rg`/`sed`/`nl` inspections; all checks showed the updated lines present.
- Ran a repository diff and status inspection to confirm only documentation prompts were edited, and validated the diff includes the new `jq` expressions and race-verdict wording; the checks succeeded.
- Confirmed this is documentation-only (no runtime code paths changed) and the new wording and commands are syntactic and self-contained for callers to copy into scheduler runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698f59249a24832bb6d014d3b39a8524)