### PR TITLE
fix(scheduler): relax hard stop on Draft PR creation failure

### DIFF
--- a/docs/agents/prompts/daily-scheduler.md
+++ b/docs/agents/prompts/daily-scheduler.md
@@ -182,9 +182,11 @@ Complete the following in this exact order. Do not reorder or skip steps:
 6. Re-run the claim check command.
 7. Only then proceed to Step 3 (task execution).
 
-### 2b. Draft PR requirement (hard stop)
+### 2b. Draft PR requirement (soft fail)
 
-If draft PR creation fails for any reason, **abort the run immediately**, mark the scheduler attempt as failed, and **do not execute the task body**.
+Try to open a draft PR immediately after the push.
+- If successful: Record the PR number.
+- If failed (e.g., missing `GH_TOKEN`): **Do not abort.** Log the failure in the `started` file summary (e.g., "Task claimed (PR creation skipped) — execution beginning") and proceed. The pushed branch and `started` log file serve as the primary distributed lock.
 
 ### 2c. Create and push `_started.md` log file
 
@@ -232,7 +234,7 @@ If the verdict is lost, abandon your branch and go back to Step 1 to select the 
 
 ```text
 Branch pushed: yes/no
-Draft PR #: ...
+Draft PR #: ... (or "FAILED/SKIPPED")
 Started log filename: ...
 Final pre-execution claim check passed: yes/no
 ```
@@ -307,6 +309,7 @@ Use the current UTC timestamp (which will be later than the `started` file). The
 - If the agent prompt file is **empty or missing**, skip it, log the run as `failed` with summary `"Prompt file empty or missing"`, and proceed to the **next agent** in the roster.
 - If a task **fails mid-execution** (test failures, build errors), log the run as `failed` with a summary describing the failure. Still commit the log file and any partial artifacts.
 - If the task log directory is **missing**, create it: `mkdir -p docs/agents/task-logs/daily/`.
+- If **Draft PR creation fails**, fall back to log-file-only claiming (the branch + `started` file).
 - If `curl` or `jq` is **unavailable or errors**, fall back to log-file-only claiming (the `started` file). Log a warning in your summary that PR-based claim checking was degraded.
 
 ---

--- a/docs/agents/prompts/weekly-scheduler.md
+++ b/docs/agents/prompts/weekly-scheduler.md
@@ -177,9 +177,11 @@ Complete the following in this exact order. Do not reorder or skip steps:
 6. Re-run the claim check command.
 7. Only then proceed to Step 3 (task execution).
 
-### 2b. Draft PR requirement (hard stop)
+### 2b. Draft PR requirement (soft fail)
 
-If draft PR creation fails for any reason, **abort the run immediately**, mark the scheduler attempt as failed, and **do not execute the task body**.
+Try to open a draft PR immediately after the push.
+- If successful: Record the PR number.
+- If failed (e.g., missing `GH_TOKEN`): **Do not abort.** Log the failure in the `started` file summary (e.g., "Task claimed (PR creation skipped) — execution beginning") and proceed. The pushed branch and `started` log file serve as the primary distributed lock.
 
 ### 2c. Create and push `_started.md` log file
 
@@ -227,7 +229,7 @@ If the verdict is lost, abandon your branch and go back to Step 1 to select the 
 
 ```text
 Branch pushed: yes/no
-Draft PR #: ...
+Draft PR #: ... (or "FAILED/SKIPPED")
 Started log filename: ...
 Final pre-execution claim check passed: yes/no
 ```
@@ -304,6 +306,7 @@ Use the current UTC timestamp (which will be later than the `started` file). The
 - If the agent prompt file is **empty or missing**, skip it, log the run as `failed` with summary `"Prompt file empty or missing"`, and proceed to the **next agent** in the roster.
 - If a task **fails mid-execution** (test failures, build errors), log the run as `failed` with a summary describing the failure. Still commit the log file and any partial artifacts.
 - If the task log directory is **missing**, create it: `mkdir -p docs/agents/task-logs/weekly/`.
+- If **Draft PR creation fails**, fall back to log-file-only claiming (the branch + `started` file).
 - If `curl` or `jq` is **unavailable or errors**, fall back to log-file-only claiming (the `started` file). Log a warning in your summary that PR-based claim checking was degraded.
 
 ---


### PR DESCRIPTION
The daily and weekly scheduler prompts included a "hard stop" rule that aborted execution if Draft PR creation failed. In restricted environments (like the agent sandbox), `GH_TOKEN` is unavailable, preventing API write access even if git operations work.

This change modifies `docs/agents/prompts/daily-scheduler.md` and `docs/agents/prompts/weekly-scheduler.md` to implement a "soft fail" policy:
- If PR creation fails (e.g., missing credentials), the agent logs the failure in the `_started.md` file summary and proceeds.
- The pushed branch and `_started.md` log file serve as the primary distributed lock.
- Updates the checklist template to accept "FAILED/SKIPPED" for the PR number.

This ensures the scheduler can operate in constrained environments without sacrificing the core distributed locking mechanism.

---
*PR created automatically by Jules for task [2731166544800841818](https://jules.google.com/task/2731166544800841818) started by @PR0M3TH3AN*