### PR TITLE
[agents] clarify scheduler override over generic AGENTS workflow

### DIFF
--- a/docs/agents/prompts/scheduler-flow.md
+++ b/docs/agents/prompts/scheduler-flow.md
@@ -2,6 +2,23 @@
 
 Use this document for **all scheduler runs**.
 
+## Scheduler Override (Top-Line Rule)
+
+During scheduler execution, the scheduler-specific instructions in this document and the cadence prompt (`daily-scheduler.md` or `weekly-scheduler.md`) **supersede generic AGENTS workflow details** when they conflict.
+
+### Global rules that still apply
+
+- Follow core safety and policy constraints (no harmful behavior, no secret exfiltration, no policy violations).
+- Do not perform destructive or irreversible actions unless explicitly required by the scheduler task definition.
+- Keep repository integrity checks (e.g., required lint/test commands in the scheduler flow) and leave an auditable log trail.
+- Respect non-interactive execution constraints and do not pause for manual approvals.
+
+### Generic AGENTS workflow details intentionally ignored for scheduler runs
+
+- The normal "one subsystem per PR" restriction, because scheduler operations are orchestration/meta-work that may touch scheduler logs, prompts, and coordination docs together.
+- The standard task-claim sequence described for general agents when it conflicts with the stricter, numbered MUST sequence below.
+- Generic start-of-task bookkeeping patterns not referenced by scheduler prompts (for example, creating extra context/todo artifacts) when they would add noise to automated scheduler runs.
+
 ## Numbered MUST Procedure
 
 1. **MUST** set cadence variables before any command:


### PR DESCRIPTION
### Motivation

- Make scheduler behavior explicit so automated daily/weekly runs are authoritative and do not conflict with generic agent guidance. 
- Reduce ambiguity by calling out which global rules remain enforced and which AGENTS workflow expectations are intentionally relaxed for scheduler executions.

### Description

- Added a `## Scheduler Override (Top-Line Rule)` section to `docs/agents/prompts/scheduler-flow.md` that states scheduler-specific instructions supersede generic AGENTS workflow details when they conflict. 
- Enumerated global rules that still apply (safety/policy constraints, no destructive or irreversible actions unless required, preservation of repository integrity checks, and non-interactive execution constraints). 
- Listed generic AGENTS workflow details intentionally ignored for scheduler runs (the usual "one subsystem per PR" restriction when in conflict, the generic task-claim sequence when it conflicts with the scheduler's MUST sequence, and additional start-of-task bookkeeping not required by scheduler prompts).

### Testing

- Ran `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698f7daf3040832bb78dc2ded460ed43)