### PR TITLE
[torch] Add migration map and extraction/verification checklists

### DIFF
--- a/torch/README.md
+++ b/torch/README.md
@@ -9,6 +9,36 @@ This folder is a repo-ready extraction of TORCH so you can move it into a standa
 - `src/prompts/` — Generic scheduler prompts and flow
 - `examples/bitvid/` — Bitvid-specific scheduler overlay examples
 
+## Migration map (bitvid ➜ torch extract)
+
+Use this mapping when extracting TORCH from bitvid into this portable folder.
+
+| bitvid source path | torch destination path |
+| --- | --- |
+| `scripts/agent/nostr-lock.mjs` | `torch/src/nostr-lock.mjs` |
+| `docs/agents/TORCH.md` | `torch/src/docs/TORCH.md` |
+| `docs/agents/prompts/*` | `torch/src/prompts/*` and `torch/examples/bitvid/*` |
+| `views/dev/agent-dashboard.html` | `torch/dashboard/index.html` |
+
+### Leave source intact (copy-only, non-destructive)
+
+Use this checklist to ensure extraction does **not** mutate or remove any bitvid source files:
+
+- [ ] Copy files from bitvid source paths into `torch/...`; do not move/rename originals.
+- [ ] Do not delete or rewrite files under `scripts/agent/`, `docs/agents/`, or `views/dev/` during extraction.
+- [ ] Keep bitvid runtime paths valid (existing docs and scripts should continue to work in-place).
+- [ ] When adapting portable files, edit only the copied torch targets (`torch/src/...`, `torch/examples/...`, `torch/dashboard/...`).
+- [ ] Confirm `git status` in bitvid does not show source removals caused by extraction.
+
+### Verification checklist (namespace/tag parity)
+
+Confirm namespace/tag identifiers are consistent across CLI, docs, and dashboard wiring:
+
+- [ ] CLI defaults/constants in `torch/src/nostr-lock.mjs` match documented values in `torch/src/docs/TORCH.md`.
+- [ ] Prompt documentation in `torch/src/prompts/*` and `torch/examples/bitvid/*` references the same namespace usage as the CLI (for example `NOSTR_LOCK_NAMESPACE`).
+- [ ] Dashboard filters in `torch/dashboard/index.html` match the same lock tag namespace used by the CLI and docs.
+- [ ] Event kind/tag examples stay aligned across all three surfaces (CLI output/examples, protocol docs, dashboard expectations).
+
 ## Drop-in notes
 
 1. Copy this `torch/` directory into your destination repository.


### PR DESCRIPTION
### Motivation
- Provide an explicit mapping and safe-extraction guidance for moving TORCH assets out of the bitvid repo so maintainers can copy files without breaking the source project or losing namespace/tag parity.

### Description
- Added a `Migration map` to `torch/README.md` mapping `scripts/agent/nostr-lock.mjs` → `torch/src/nostr-lock.mjs`, `docs/agents/TORCH.md` → `torch/src/docs/TORCH.md`, `docs/agents/prompts/*` → `torch/src/prompts/*` and `torch/examples/bitvid/*`, and `views/dev/agent-dashboard.html` → `torch/dashboard/index.html`.
- Added a `Leave source intact (copy-only, non-destructive)` checklist that mandates copying rather than moving or deleting original bitvid files.
- Added a `Verification checklist (namespace/tag parity)` to ensure CLI defaults, prompt docs, and dashboard filters use the same namespace/tag values.
- Modified file: `torch/README.md`.

### Testing
- Ran `git diff -- torch/README.md` to inspect the patch and it showed the new migration and checklists, which succeeded.
- Ran `git status --short` to verify the repository state and it reported the updated `torch/README.md` file, which succeeded.
- Displayed the updated README with `nl -ba torch/README.md | sed -n '1,220p'` to validate content placement, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698fce46aaf4832ba96b13d12a333123)