### PR TITLE
Daily Agent: const-refactor-agent (NIP-07 & NIP-46 Timeouts)

### DIFF
--- a/context/CONTEXT_2026-02-14_04-30-00.md
+++ b/context/CONTEXT_2026-02-14_04-30-00.md
@@ -1,0 +1,13 @@
+# Context: NIP-07 and NIP-46 Timeout Refactor
+
+## Goal
+Refactor duplicate `5000` ms timeout literals in Nostr-related modules to use semantic constants.
+
+## Scope
+- `js/nostr/nip07Permissions.js`: Define `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.
+- `js/nostr/managers/SignerManager.js`: Use `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.
+- `js/nostr/nip46Client.js`: Define `NIP46_PING_TIMEOUT_MS`.
+
+## Baseline
+- Branch: `unstable` (assumed)
+- Node: `v22.22.0`

--- a/decisions/DECISIONS_2026-02-14_04-30-00.md
+++ b/decisions/DECISIONS_2026-02-14_04-30-00.md
@@ -1,0 +1,13 @@
+# Decisions: NIP-07 and NIP-46 Timeout Refactor
+
+## NIP-07 Extension Timeout
+- **Value**: `5000` ms.
+- **Constant**: `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.
+- **Location**: `js/nostr/nip07Permissions.js`.
+- **Reasoning**: This module exports `waitForNip07Extension`, so it is the natural home for the default timeout constant. `SignerManager.js` imports it from there.
+
+## NIP-46 Ping Timeout
+- **Value**: `5000` ms.
+- **Constant**: `NIP46_PING_TIMEOUT_MS`.
+- **Location**: `js/nostr/nip46Client.js`.
+- **Reasoning**: Specific to the `ping()` RPC call in this client. Kept local to the file as it's not widely shared.

--- a/docs/agents/task-logs/daily/2026-02-14_04-30-00_const-refactor-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-14_04-30-00_const-refactor-agent_completed.md
@@ -1,0 +1,25 @@
+# Task Completion Log
+
+- **Agent**: `const-refactor-agent`
+- **Cadence**: `daily`
+- **Date**: `2026-02-14`
+- **Start Time**: `04:30:00`
+- **End Time**: `04:35:00`
+- **Status**: `completed`
+
+## Summary
+Refactored duplicate `5000` ms timeout literals in `js/nostr/nip07Permissions.js`, `js/nostr/managers/SignerManager.js`, and `js/nostr/nip46Client.js` to use semantic constants `NIP07_EXTENSION_WAIT_TIMEOUT_MS` and `NIP46_PING_TIMEOUT_MS`.
+
+## Changes
+- `js/nostr/nip07Permissions.js`: Added `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.
+- `js/nostr/managers/SignerManager.js`: Updated to import and use `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.
+- `js/nostr/nip46Client.js`: Added `NIP46_PING_TIMEOUT_MS`.
+
+## Verification
+- `npm run lint`: Passed.
+- `npm run test:unit`: Passed.
+
+## Artifacts
+- `context/CONTEXT_2026-02-14_04-30-00.md`
+- `decisions/DECISIONS_2026-02-14_04-30-00.md`
+- `test_logs/TEST_LOG_2026-02-14_04-30-00.md`

--- a/js/nostr/managers/SignerManager.js
+++ b/js/nostr/managers/SignerManager.js
@@ -8,6 +8,7 @@ import {
 } from "../sessionActor.js";
 import {
   waitForNip07Extension,
+  NIP07_EXTENSION_WAIT_TIMEOUT_MS,
   requestEnablePermissions,
   normalizePermissionMethod,
   readStoredNip07Permissions,
@@ -390,7 +391,7 @@ export class SignerManager {
 
     if (!extension && this.extensionPermissionCache && this.extensionPermissionCache.size > 0) {
       try {
-        await waitForNip07Extension(5000);
+        await waitForNip07Extension(NIP07_EXTENSION_WAIT_TIMEOUT_MS);
         extension = window.nostr;
       } catch (error) {
         // Fall through to existing signer check

--- a/js/nostr/nip07Permissions.js
+++ b/js/nostr/nip07Permissions.js
@@ -1,6 +1,7 @@
 import { devLogger, userLogger } from "../utils/logger.js";
 
 export const NIP07_LOGIN_TIMEOUT_MS = 60_000; // 60 seconds
+export const NIP07_EXTENSION_WAIT_TIMEOUT_MS = 5000;
 export const NIP07_LOGIN_TIMEOUT_ERROR_MESSAGE =
   "Timed out waiting for the NIP-07 extension. Confirm the extension prompt in your browser toolbar and try again.";
 const NIP07_PERMISSIONS_STORAGE_KEY = "bitvid:nip07:permissions";
@@ -387,7 +388,7 @@ export const __testExports = {
   normalizePermissionMethod,
 };
 
-export function waitForNip07Extension(timeoutMs = 5000) {
+export function waitForNip07Extension(timeoutMs = NIP07_EXTENSION_WAIT_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     if (typeof window !== "undefined" && window.nostr) {
       resolve(window.nostr);

--- a/js/nostr/nip46Client.js
+++ b/js/nostr/nip46Client.js
@@ -46,6 +46,7 @@ import {
 export const NIP46_RPC_KIND = 24_133;
 const NIP46_SESSION_STORAGE_KEY = "bitvid:nip46:session:v1";
 const NIP46_PUBLISH_TIMEOUT_MS = 8_000;
+const NIP46_PING_TIMEOUT_MS = 5000;
 const NIP46_RESPONSE_TIMEOUT_MS = 15_000;
 const NIP46_SIGN_EVENT_TIMEOUT_MS = 20_000;
 const NIP46_MAX_RETRIES = 1;
@@ -1877,7 +1878,7 @@ export class Nip46RpcClient {
   async ping() {
     try {
       const result = await this.sendRpc("ping", [], {
-        timeoutMs: 5000,
+        timeoutMs: NIP46_PING_TIMEOUT_MS,
         retries: 0,
         priority: NIP46_PRIORITY.HIGH,
       });

--- a/test_logs/TEST_LOG_2026-02-14_04-30-00.md
+++ b/test_logs/TEST_LOG_2026-02-14_04-30-00.md
@@ -1,0 +1,13 @@
+# Test Log: NIP-07 and NIP-46 Timeout Refactor
+
+## Commands
+- `npm run lint`
+- `npm run test:unit`
+
+## Results
+- Lint: Passed.
+- Tests: Passed.
+
+```
+✔ All unit tests passed
+```


### PR DESCRIPTION
Executed the daily `const-refactor-agent` task.
- Refactored duplicate `5000` ms timeouts in `js/nostr/nip07Permissions.js`, `js/nostr/managers/SignerManager.js`, and `js/nostr/nip46Client.js` to use semantic constants `NIP07_EXTENSION_WAIT_TIMEOUT_MS` and `NIP46_PING_TIMEOUT_MS`.
- Verified with lint and unit tests.
- Generated execution artifacts in `context/`, `decisions/`, `test_logs/`.
- Created scheduler completion log: `docs/agents/task-logs/daily/2026-02-14_04-30-00_const-refactor-agent_completed.md`.

---
*PR created automatically by Jules for task [7218137935636078560](https://jules.google.com/task/7218137935636078560) started by @PR0M3TH3AN*