### PR TITLE
docs: align instance-config with codebase behavior (docs-alignment-agent)

### DIFF
--- a/docs/agents/task-logs/daily/2026-02-14_16-37-27_docs-alignment-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-14_16-37-27_docs-alignment-agent_completed.md
@@ -1,0 +1,30 @@
+# Daily Docs Alignment
+
+**Agent**: docs-alignment-agent
+**Date**: 2026-02-14
+**Status**: Completed
+
+## Summary
+
+Audited `README.md`, `CONTRIBUTING.md`, `package.json`, and `docs/instance-config.md` against the codebase. Found that the documentation is largely accurate and aligned with the current implementation. Identified one missing configuration option in `docs/instance-config.md`.
+
+## Claims Map
+
+| Document | Claim | Code Location | Status | Notes |
+|---|---|---|---|---|
+| `README.md` | `npm start` runs build & serve | `package.json` | ✅ | Matches `npm run build && npx serve dist` |
+| `README.md` | `npm run build` generates `dist/` | `scripts/build-dist.mjs` | ✅ | Verified by script existence |
+| `README.md` | `npm run test:unit` runs unit tests | `package.json` | ✅ | Matches `scripts/run-unit-tests.mjs` |
+| `README.md` | `npm run lint` checks styles/tokens | `package.json` | ✅ | Matches lint script composition |
+| `README.md` | `buildVideoPostEvent` usage | `js/nostrEventSchemas.js` | ✅ | Schema builder matches example |
+| `docs/instance-config.md` | List of exported config constants | `config/instance-config.js` | ⚠️ | Missing `ENABLE_NIP17_RELAY_WARNING` |
+
+## Updates
+
+- **`docs/instance-config.md`**: Added documentation for `ENABLE_NIP17_RELAY_WARNING` to the new "Direct Message privacy" section.
+
+## Verification
+
+- **Lint**: Ran `npm run lint` successfully.
+- **Manual Verification**: Read `docs/instance-config.md` to confirm the update.
+- **Code Match**: Verified `ENABLE_NIP17_RELAY_WARNING` exists in `config/instance-config.js`.

--- a/docs/instance-config.md
+++ b/docs/instance-config.md
@@ -280,3 +280,9 @@ can be injected at build time.
   - **Why change it:** If the preferred source does not reach the "playing" state within this
     window, the player switches to the fallback source. This prevents users from staring at a
     loading spinner indefinitely.
+
+### Direct Message privacy
+
+- **`ENABLE_NIP17_RELAY_WARNING`**
+  - **What it does:** Whether to display privacy warnings when NIP-17 DM relay lists are missing (falling back to legacy routing).
+  - **Why change it:** Set to `true` to warn users about potential privacy leaks; set to `false` (default) for a quieter experience.


### PR DESCRIPTION
Updated `docs/instance-config.md` to include `ENABLE_NIP17_RELAY_WARNING`.

## Claims Map

| Document | Claim | Code Location | Status | Notes |
|---|---|---|---|---|
| `README.md` | `npm start` runs build & serve | `package.json` | ✅ | Matches `npm run build && npx serve dist` |
| `README.md` | `npm run build` generates `dist/` | `scripts/build-dist.mjs` | ✅ | Verified by script existence |
| `README.md` | `npm run test:unit` runs unit tests | `package.json` | ✅ | Matches `scripts/run-unit-tests.mjs` |
| `README.md` | `npm run lint` checks styles/tokens | `package.json` | ✅ | Matches lint script composition |
| `README.md` | `buildVideoPostEvent` usage | `js/nostrEventSchemas.js` | ✅ | Schema builder matches example |
| `docs/instance-config.md` | List of exported config constants | `config/instance-config.js` | ⚠️ | Missing `ENABLE_NIP17_RELAY_WARNING` |

## Updates

- **`docs/instance-config.md`**: Added documentation for `ENABLE_NIP17_RELAY_WARNING` to the new "Direct Message privacy" section.


---
*PR created automatically by Jules for task [7159653018557731210](https://jules.google.com/task/7159653018557731210) started by @PR0M3TH3AN*