### PR TITLE
docs(agents): sync scheduler rosters — 2026-02-15

### DIFF
--- a/context/CONTEXT_2026-02-15_17-56-50.md
+++ b/context/CONTEXT_2026-02-15_17-56-50.md
@@ -1,0 +1,12 @@
+# Context - Scheduler Update Agent Run
+
+## Goal
+Keep the daily and weekly scheduler rosters in sync with the actual prompt files on disk.
+
+## Status
+Completed.
+
+## Findings
+- Daily prompts: 21 files. Roster matches.
+- Weekly prompts: 16 files. Roster matches.
+- No changes needed to scheduler files.

--- a/decisions/DECISIONS_2026-02-15_17-56-50.md
+++ b/decisions/DECISIONS_2026-02-15_17-56-50.md
@@ -1,0 +1,5 @@
+# Decisions - Scheduler Update Agent Run
+
+## 1. No changes applied
+- **Rationale**: The rosters in `daily-scheduler.md` and `weekly-scheduler.md` already perfectly match the file inventory on disk.
+- **Action**: Skipped writing to scheduler files to avoid unnecessary commits/churn.

--- a/docs/agents/task-logs/daily/2026-02-15_17-59-53_scheduler-update-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-15_17-59-53_scheduler-update-agent_completed.md
@@ -1,0 +1,16 @@
+# Scheduler Update Agent Run - Completed
+
+## Summary
+Successfully verified and synchronized scheduler rosters with prompt files on disk.
+
+## Status
+- **Daily Prompts**: 21 files found. Roster matches.
+- **Weekly Prompts**: 16 files found. Roster matches.
+- **Actions**: No changes were needed to scheduler files as they were already in sync.
+
+## Persistent State
+Created the following persistent state files:
+- `context/CONTEXT_2026-02-15_17-56-50.md`
+- `todo/TODO_2026-02-15_17-56-50.md`
+- `decisions/DECISIONS_2026-02-15_17-56-50.md`
+- `test_logs/TEST_LOG_2026-02-15_17-56-50.md`

--- a/test_logs/TEST_LOG_2026-02-15_17-56-50.md
+++ b/test_logs/TEST_LOG_2026-02-15_17-56-50.md
@@ -1,0 +1,18 @@
+# Test Log - Scheduler Update Agent Run
+
+## Verification Commands
+
+### Daily Count
+```bash
+ls docs/agents/prompts/daily/*.md | wc -l
+```
+**Result**: 21 (Matches roster)
+
+### Weekly Count
+```bash
+ls docs/agents/prompts/weekly/*.md | wc -l
+```
+**Result**: 16 (Matches roster)
+
+## Conclusion
+All rosters are in sync.

--- a/todo/TODO_2026-02-15_17-56-50.md
+++ b/todo/TODO_2026-02-15_17-56-50.md
@@ -1,0 +1,8 @@
+# Todo - Scheduler Update Agent Run
+
+- [x] Read AGENTS.md and CLAUDE.md
+- [x] Inventory prompt files in daily/ and weekly/
+- [x] Read daily-scheduler.md and weekly-scheduler.md
+- [x] Compare files vs rosters
+- [x] Apply changes (None needed)
+- [x] Verify counts match


### PR DESCRIPTION
Executed `bitvid-scheduler-update-agent`.
- Verified 21 daily prompts.
- Verified 16 weekly prompts.
- Confirmed rosters in `daily-scheduler.md` and `weekly-scheduler.md` match files on disk.
- Created persistent state files (`context`, `todo`, `decisions`, `test_logs`) as per instructions.
- No changes made to scheduler files.

---
*PR created automatically by Jules for task [475622022122142659](https://jules.google.com/task/475622022122142659) started by @PR0M3TH3AN*