### PR TITLE
chore(scheduler): run daily audit-agent

### DIFF
--- a/context/CONTEXT_2026-02-16_00-00-00.md
+++ b/context/CONTEXT_2026-02-16_00-00-00.md
@@ -1,0 +1,8 @@
+# Context: Daily Audit Agent Run
+
+- **Target Branch**: `unstable`
+- **Date**: 2026-02-16
+- **Agent**: bitvid-audit-agent (via daily scheduler)
+- **Node Version**: v22.22.0
+- **OS**: Linux
+- **Purpose**: Run static audit scripts, collect metrics, and generate a regression report.

--- a/decisions/DECISIONS_2026-02-16_00-00-00.md
+++ b/decisions/DECISIONS_2026-02-16_00-00-00.md
@@ -1,0 +1,3 @@
+# Decisions: Daily Audit Agent Run
+
+- **Comparison Baseline**: Using `artifacts/audit/2026-02-12/` as the baseline for comparison since it's the most recent report available in the artifacts directory.

--- a/docs/agents/task-logs/daily/2026-02-16_00-41-30_audit-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_00-41-30_audit-agent_completed.md
@@ -1,0 +1,1 @@
+Audit completed successfully. See artifacts/audit/2026-02-16/summary.md for details.

--- a/test_logs/TEST_LOG_2026-02-16_00-00-00.md
+++ b/test_logs/TEST_LOG_2026-02-16_00-00-00.md
@@ -1,0 +1,134 @@
+# Test Log: Daily Audit Agent Run
+
+Started at: 2026-02-16 00:00:00 UTC
+--- check-file-size.mjs ---
+
+43 grandfathered oversized file(s):
+  ⚠ grandfathered: js/adminListStore.js (1033 lines)
+  ⚠ grandfathered: js/app/authSessionCoordinator.js (1743 lines)
+  ⚠ grandfathered: js/app/feedCoordinator.js (1767 lines)
+  ⚠ grandfathered: js/app/playbackCoordinator.js (1217 lines)
+  ⚠ grandfathered: js/app.js (5135 lines)
+  ⚠ grandfathered: js/channelProfile.js (5577 lines)
+  ⚠ grandfathered: js/feedEngine/stages.js (1350 lines)
+  ⚠ grandfathered: js/historyView.js (2547 lines)
+  ⚠ grandfathered: js/index.js (1409 lines)
+  ⚠ grandfathered: js/nostr/client.js (3997 lines)
+  ⚠ grandfathered: js/nostr/managers/SignerManager.js (1107 lines)
+  ⚠ grandfathered: js/nostr/nip46Client.js (2103 lines)
+  ⚠ grandfathered: js/nostr/nip46Connector.js (1094 lines)
+  ⚠ grandfathered: js/nostr/nip71.js (1531 lines)
+  ⚠ grandfathered: js/nostr/publishHelpers.js (1415 lines)
+  ⚠ grandfathered: js/nostr/watchHistory.js (2211 lines)
+  ⚠ grandfathered: js/nostrEventSchemas.js (2913 lines)
+  ⚠ grandfathered: js/payments/nwcClient.js (1642 lines)
+  ⚠ grandfathered: js/services/authService.js (1321 lines)
+  ⚠ grandfathered: js/services/commentThreadService.js (1122 lines)
+  ⚠ grandfathered: js/services/hashtagPreferencesService.js (1435 lines)
+  ⚠ grandfathered: js/services/moderationService.js (2513 lines)
+  ⚠ grandfathered: js/services/nostrService.js (2227 lines)
+  ⚠ grandfathered: js/services/playbackService.js (1289 lines)
+  ⚠ grandfathered: js/services/r2Service.js (1194 lines)
+  ⚠ grandfathered: js/state/cache.js (1829 lines)
+  ⚠ grandfathered: js/subscriptions.js (2407 lines)
+  ⚠ grandfathered: js/ui/applicationBootstrap.js (1169 lines)
+  ⚠ grandfathered: js/ui/components/EditModal.js (1130 lines)
+  ⚠ grandfathered: js/ui/components/RevertModal.js (1509 lines)
+  ⚠ grandfathered: js/ui/components/SimilarContentCard.js (1303 lines)
+  ⚠ grandfathered: js/ui/components/UploadModal.js (1320 lines)
+  ⚠ grandfathered: js/ui/components/VideoCard.js (3130 lines)
+  ⚠ grandfathered: js/ui/components/VideoModal.js (6045 lines)
+  ⚠ grandfathered: js/ui/loginModalController.js (2577 lines)
+  ⚠ grandfathered: js/ui/moreMenuController.js (1601 lines)
+  ⚠ grandfathered: js/ui/overlay/popoverEngine.js (1070 lines)
+  ⚠ grandfathered: js/ui/profileModalController.js (6258 lines)
+  ⚠ grandfathered: js/ui/views/VideoListView.js (1392 lines)
+  ⚠ grandfathered: js/ui/zapController.js (1206 lines)
+  ⚠ grandfathered: js/userBlocks.js (2305 lines)
+  ⚠ grandfathered: js/watchHistoryService.js (1400 lines)
+  ⚠ grandfathered: js/webtorrent.js (1038 lines)
+
+No violations. 43 grandfathered file(s) remain as decomposition targets.
+--- check-innerhtml.mjs ---
+innerHTML usage: 60 assignments across 31 files
+
+  js/docsView.js: 8
+  js/ui/subscriptionHistoryController.js: 7
+  js/historyView.js: 4
+  js/ui/components/DeleteModal.js: 3
+  js/ui/components/ShareNostrModal.js: 3
+  js/ui/dm/DMSettingsModalController.js: 3
+  js/ui/loginModalController.js: 3
+  js/ui/views/VideoListView.js: 3
+  js/viewManager.js: 3
+  js/utils/qrcode.js: 2
+  js/app/feedCoordinator.js: 1
+  js/app.js: 1
+  js/exploreView.js: 1
+  js/forYouView.js: 1
+  js/index.js: 1
+  js/kidsView.js: 1
+  js/ui/components/EditModal.js: 1
+  js/ui/components/EmbedVideoModal.js: 1
+  js/ui/components/EventDetailsModal.js: 1
+  js/ui/components/UploadModal.js: 1
+  js/ui/components/VideoModal.js: 1
+  js/ui/components/nip71FormManager.js: 1
+  js/ui/dm/AppShell.js: 1
+  js/ui/dm/Composer.js: 1
+  js/ui/dm/ConversationList.js: 1
+  js/ui/dm/DMRelaySettings.js: 1
+  js/ui/dm/MessageThread.js: 1
+  js/ui/dm/NotificationCenter.js: 1
+  js/ui/moreMenuController.js: 1
+  js/ui/profileModalController.js: 1
+  js/ui/videoListViewController.js: 1
+--- npm run lint ---
+
+> bitvid@1.0.0 lint
+> npm run lint:css && npm run lint:hex && npm run lint:inline-styles && npm run lint:tokens && npm run lint:tailwind-brackets && npm run lint:tailwind-colors && npm run lint:file-size && npm run lint:innerhtml && npm run lint:assets && npm run lint:sw-compat
+
+
+> bitvid@1.0.0 lint:css
+> stylelint css/tailwind.source.css css/tokens.css css/docs.css
+
+
+> bitvid@1.0.0 lint:hex
+> node scripts/check-hex.js
+
+
+> bitvid@1.0.0 lint:inline-styles
+> node scripts/check-inline-styles.mjs
+
+No inline style usage found.
+
+> bitvid@1.0.0 lint:tokens
+> node scripts/check-design-tokens.mjs --check=tokens
+
+
+> bitvid@1.0.0 lint:tailwind-brackets
+> node scripts/check-design-tokens.mjs --check=brackets
+
+
+> bitvid@1.0.0 lint:tailwind-colors
+> node scripts/check-tailwind-colors.mjs
+
+
+> bitvid@1.0.0 lint:file-size
+> node scripts/check-file-size.mjs
+
+
+> bitvid@1.0.0 lint:innerhtml
+> node scripts/check-innerhtml.mjs
+
+
+> bitvid@1.0.0 lint:assets
+> node scripts/check-asset-references.mjs
+
+[lint:assets] Missing dist/asset-manifest.json. Skipping asset reference check (build required).
+
+> bitvid@1.0.0 lint:sw-compat
+> node scripts/check-sw-compat.mjs
+
+[sw-compat] Skipping check: unable to determine HEAD^ or git history unavailable.
+[sw-compat] No commit delta found; skipping compatibility check.

--- a/todo/TODO_2026-02-16_00-00-00.md
+++ b/todo/TODO_2026-02-16_00-00-00.md
@@ -1,0 +1,13 @@
+# TODO: Daily Audit Agent Run
+
+- [x] Create artifacts directory `artifacts/audit/2026-02-16/`
+- [x] Run `check-file-size.mjs`
+- [x] Run `check-innerhtml.mjs`
+- [x] Run `npm run lint`
+- [x] Parse file size report
+- [x] Parse innerHTML report
+- [x] Parse lint report
+- [x] Compare with previous report (2026-02-12)
+- [x] Generate summary report
+- [x] Verify summary report
+- [ ] Submit changes


### PR DESCRIPTION
Executed the `audit-agent` via the daily scheduler.
- Ran static analysis scripts (`check-file-size.mjs`, `check-innerhtml.mjs`, `npm run lint`).
- Parsed logs and generated JSON reports in `artifacts/audit/2026-02-16/`.
- Generated `summary.md` comparing metrics with the previous run (2026-02-12).
- Created scheduler completion log in `docs/agents/task-logs/daily/`.

---
*PR created automatically by Jules for task [6569359284864060260](https://jules.google.com/task/6569359284864060260) started by @PR0M3TH3AN*