### PR TITLE
[constants] Refactor timeouts and limits

### DIFF
--- a/decisions/DECISIONS_2026-02-16.md
+++ b/decisions/DECISIONS_2026-02-16.md
@@ -1,0 +1,13 @@
+# Constant Refactoring Decisions
+
+## 2026-02-16
+
+- **5000 ms used for UI toast duration:**
+  - Chosen canonical constant: `SHORT_TIMEOUT_MS` (from `js/constants.js`)
+  - Location: `js/ui/videoModalController.js`
+  - Reason: `SHORT_TIMEOUT_MS` is already 5000 and semantically fits "short timeout" for auto-hiding status.
+
+- **5000 as MAX_BLOCKLIST_ENTRIES:**
+  - Chosen canonical constant: `MAX_BLOCKLIST_ENTRIES`
+  - Location: `js/constants.js`
+  - Reason: `MAX_BLOCKLIST_ENTRIES` was defined locally in `js/userBlocks.js`. Extracted to `js/constants.js` to centralize limits.

--- a/docs/agents/task-logs/daily/2026-02-16_03-55-00_const-refactor-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_03-55-00_const-refactor-agent_completed.md
@@ -1,0 +1,26 @@
+# Daily Agent Task Log: const-refactor-agent
+
+- **Date**: 2026-02-16
+- **Agent**: const-refactor-agent
+- **Status**: Completed
+
+## Tasks Performed
+
+1.  **Refactor `js/ui/videoModalController.js`**:
+    - Replaced `autoHideMs: 5000` with `SHORT_TIMEOUT_MS` (imported from `js/constants.js`).
+    - Verified with `tests/unit/ui/videoModalController.test.mjs`.
+
+2.  **Refactor `js/userBlocks.js`**:
+    - Extracted `MAX_BLOCKLIST_ENTRIES = 5000` to `js/constants.js`.
+    - Imported `MAX_BLOCKLIST_ENTRIES` in `js/userBlocks.js`.
+    - Verified with `tests/user-blocks.test.mjs` (noted pre-existing failure unrelated to changes).
+
+## Verification
+
+- `npm run lint`: Passed.
+- `node scripts/run-targeted-tests.mjs tests/unit/ui/videoModalController.test.mjs`: Passed.
+- `node scripts/run-targeted-tests.mjs tests/user-blocks.test.mjs`: Failed with pre-existing `login-mode load should settle quickly` timeout (5000ms). Verified by reverting changes and confirming failure persists.
+
+## Decisions
+
+- Created `decisions/DECISIONS_2026-02-16.md` documenting the refactors.

--- a/js/constants.js
+++ b/js/constants.js
@@ -24,6 +24,9 @@ export const STANDARD_TIMEOUT_MS = 10000;
 export const MEDIUM_TIMEOUT_MS = 30000;
 export const LONG_TIMEOUT_MS = 60000;
 
+// Limits
+export const MAX_BLOCKLIST_ENTRIES = 5000;
+
 export const UI_FEEDBACK_DELAY_MS = 2000;
 export const DEBOUNCE_DELAY_MS = 2000;
 export const NETWORK_RETRY_DELAY_MS = 1500;

--- a/js/ui/videoModalController.js
+++ b/js/ui/videoModalController.js
@@ -1,4 +1,5 @@
 import { devLogger, userLogger } from "../utils/logger.js";
+import { SHORT_TIMEOUT_MS } from "../constants.js";
 
 export default class VideoModalController {
   constructor({
@@ -180,7 +181,7 @@ export default class VideoModalController {
       if (this.showStatus) {
         this.showStatus(
           "Warning: No peers detected. Playback may fail or stall.",
-          { autoHideMs: 5000 },
+          { autoHideMs: SHORT_TIMEOUT_MS },
         );
       }
       // Proceed anyway

--- a/js/userBlocks.js
+++ b/js/userBlocks.js
@@ -14,7 +14,7 @@ import {
 } from "./nostrEventSchemas.js";
 import { CACHE_POLICIES, STORAGE_TIERS } from "./nostr/cachePolicies.js";
 import { devLogger, userLogger } from "./utils/logger.js";
-import { STANDARD_TIMEOUT_MS } from "./constants.js";
+import { STANDARD_TIMEOUT_MS, MAX_BLOCKLIST_ENTRIES } from "./constants.js";
 import {
   publishEventToRelays,
   assertAnyRelayAccepted,
@@ -92,7 +92,6 @@ const DECRYPT_TIMEOUT_MS = STANDARD_TIMEOUT_MS;
 const BACKGROUND_DECRYPT_TIMEOUT_MS = 8000;
 // PERF: Reduced from 10s to 3s for faster recovery during login.
 const DECRYPT_RETRY_DELAY_MS = 3000;
-const MAX_BLOCKLIST_ENTRIES = 5000;
 
 function sanitizeRelayList(candidate) {
   return Array.isArray(candidate)


### PR DESCRIPTION
Extracted `MAX_BLOCKLIST_ENTRIES` to `js/constants.js` and reused `SHORT_TIMEOUT_MS` in `js/ui/videoModalController.js`. Updated imports in `js/userBlocks.js`.

Verified with `tests/unit/ui/videoModalController.test.mjs`.
Note: `tests/user-blocks.test.mjs` fails with a pre-existing timeout issue unrelated to these changes.

---
*PR created automatically by Jules for task [2356235086948599052](https://jules.google.com/task/2356235086948599052) started by @PR0M3TH3AN*