### PR TITLE
[constants] Refactor 5000ms literals to SHORT_TIMEOUT_MS

### DIFF
--- a/context/CONTEXT_2026-02-16_07-03-19.md
+++ b/context/CONTEXT_2026-02-16_07-03-19.md
@@ -1,0 +1,14 @@
+# Context: Constants Refactoring
+
+**Date**: 2026-02-16
+**Agent**: const-refactor-agent (via daily scheduler)
+**Goal**: Identify and canonicalize duplicated numeric literals.
+
+## Scope
+- Focus on the literal `5000` which appears to be a common timeout value.
+- Refactor usages to `SHORT_TIMEOUT_MS` (5000ms) where semantically appropriate.
+
+## Changes
+- `js/ui/videoModalController.js`: `autoHideMs` for status message.
+- `js/nostr/nip46Client.js`: `NIP46_PING_TIMEOUT_MS`.
+- `js/nostr/nip07Permissions.js`: `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.

--- a/decisions/DECISIONS_2026-02-16_07-03-19.md
+++ b/decisions/DECISIONS_2026-02-16_07-03-19.md
@@ -1,0 +1,17 @@
+# Decisions: Constants Refactoring
+
+**Date**: 2026-02-16
+
+## Refactoring `5000` to `SHORT_TIMEOUT_MS`
+
+- **5000 ms** used in `js/ui/videoModalController.js` for status message auto-hide.
+  - **Decision**: Use `SHORT_TIMEOUT_MS`.
+  - **Reason**: Matches the definition of a short UI timeout.
+
+- **5000 ms** used in `js/nostr/nip46Client.js` for `NIP46_PING_TIMEOUT_MS`.
+  - **Decision**: Use `SHORT_TIMEOUT_MS`.
+  - **Reason**: Ping operations should be quick.
+
+- **5000 ms** used in `js/nostr/nip07Permissions.js` for `NIP07_EXTENSION_WAIT_TIMEOUT_MS`.
+  - **Decision**: Use `SHORT_TIMEOUT_MS`.
+  - **Reason**: Waiting for extension injection is a short-duration check.

--- a/docs/agents/task-logs/daily/2026-02-16_07-03-19_const-refactor-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_07-03-19_const-refactor-agent_completed.md
@@ -1,0 +1,13 @@
+# Daily Agent Completion Log
+
+**Date**: 2026-02-16
+**Agent**: const-refactor-agent
+**Status**: Completed
+
+## Summary
+Refactored duplicated `5000` numeric literals to `SHORT_TIMEOUT_MS` in:
+- `js/ui/videoModalController.js`
+- `js/nostr/nip46Client.js`
+- `js/nostr/nip07Permissions.js`
+
+Lint and unit tests passed.

--- a/js/nostr/nip07Permissions.js
+++ b/js/nostr/nip07Permissions.js
@@ -1,7 +1,8 @@
 import { devLogger, userLogger } from "../utils/logger.js";
+import { SHORT_TIMEOUT_MS } from "../constants.js";
 
 export const NIP07_LOGIN_TIMEOUT_MS = 60_000; // 60 seconds
-export const NIP07_EXTENSION_WAIT_TIMEOUT_MS = 5000;
+export const NIP07_EXTENSION_WAIT_TIMEOUT_MS = SHORT_TIMEOUT_MS;
 export const NIP07_LOGIN_TIMEOUT_ERROR_MESSAGE =
   "Timed out waiting for the NIP-07 extension. Confirm the extension prompt in your browser toolbar and try again.";
 const NIP07_PERMISSIONS_STORAGE_KEY = "bitvid:nip07:permissions";

--- a/js/nostr/nip46Client.js
+++ b/js/nostr/nip46Client.js
@@ -42,11 +42,12 @@ import {
   summarizeRpcResultForLog,
   summarizeRelayPublishResultsForLog,
 } from "./nip46LoggingUtils.js";
+import { SHORT_TIMEOUT_MS } from "../constants.js";
 
 export const NIP46_RPC_KIND = 24_133;
 const NIP46_SESSION_STORAGE_KEY = "bitvid:nip46:session:v1";
 const NIP46_PUBLISH_TIMEOUT_MS = 8_000;
-const NIP46_PING_TIMEOUT_MS = 5000;
+const NIP46_PING_TIMEOUT_MS = SHORT_TIMEOUT_MS;
 const NIP46_RESPONSE_TIMEOUT_MS = 15_000;
 const NIP46_SIGN_EVENT_TIMEOUT_MS = 20_000;
 const NIP46_MAX_RETRIES = 1;

--- a/js/ui/videoModalController.js
+++ b/js/ui/videoModalController.js
@@ -1,4 +1,5 @@
 import { devLogger, userLogger } from "../utils/logger.js";
+import { SHORT_TIMEOUT_MS } from "../constants.js";
 
 export default class VideoModalController {
   constructor({
@@ -180,7 +181,7 @@ export default class VideoModalController {
       if (this.showStatus) {
         this.showStatus(
           "Warning: No peers detected. Playback may fail or stall.",
-          { autoHideMs: 5000 },
+          { autoHideMs: SHORT_TIMEOUT_MS },
         );
       }
       // Proceed anyway

--- a/test_logs/TEST_LOG_2026-02-16_07-03-19.md
+++ b/test_logs/TEST_LOG_2026-02-16_07-03-19.md
@@ -1,0 +1,18 @@
+# Test Log: Constants Refactoring
+
+**Date**: 2026-02-16
+
+## Commands Run
+
+1. `npm run lint`
+2. `npm run test:unit`
+
+## Results
+
+### Lint
+Passed.
+
+### Unit Tests
+Passed. `✔ All unit tests passed`
+
+(Full output available in CI logs or local `test_output.txt` if preserved)

--- a/todo/TODO_2026-02-16_07-03-19.md
+++ b/todo/TODO_2026-02-16_07-03-19.md
@@ -1,0 +1,10 @@
+# Todo: Constants Refactoring
+
+**Date**: 2026-02-16
+
+- [x] Search for `5000` in `js/`.
+- [x] Identify semantic matches for `SHORT_TIMEOUT_MS`.
+- [x] Refactor `js/ui/videoModalController.js`.
+- [x] Refactor `js/nostr/nip46Client.js`.
+- [x] Refactor `js/nostr/nip07Permissions.js`.
+- [x] Verify with lint and tests.


### PR DESCRIPTION
Refactored usage of `5000` numeric literal to `SHORT_TIMEOUT_MS` in:
- `js/ui/videoModalController.js`
- `js/nostr/nip46Client.js`
- `js/nostr/nip07Permissions.js`

Also created agent execution artifacts in `context/`, `todo/`, `decisions/`, `test_logs/` and `docs/agents/task-logs/daily/`.

---
*PR created automatically by Jules for task [409004041836644120](https://jules.google.com/task/409004041836644120) started by @PR0M3TH3AN*