### PR TITLE
[decompose] extract DM logic from js/ui/profileModalController.js

### DIFF
--- a/decisions/DECISIONS_1771241005.md
+++ b/decisions/DECISIONS_1771241005.md
@@ -1,0 +1,33 @@
+# Decisions Log
+
+**Date:** 2026-02-16
+**Agent:** bitvid-decompose-agent
+**File:** `js/ui/profileModalController.js`
+
+## Decisions
+
+### 1. Extract DM Relay Logic
+**Decision:** Extracted DM relay management logic into `ProfileDmRelayController`.
+**Rationale:** The relay logic (add, remove, publish, refresh) was cluttering the main controller and is distinct from core profile management.
+**Implementation:** Created `js/ui/profileModal/ProfileDmRelayController.js` and delegated calls from `ProfileModalController`.
+
+### 2. Extract Attachment Logic
+**Decision:** Extracted attachment handling logic into `ProfileDmAttachmentController`.
+**Rationale:** Attachment uploading, rendering queue, and file selection are a separate concern from the main profile UI.
+**Implementation:** Created `js/ui/profileModal/ProfileDmAttachmentController.js` and delegated calls from `ProfileModalController`.
+
+### 3. Move Helper Methods
+**Decision:** Moved pure helper methods (`generateAttachmentId`, `resolveLatestDirectMessageForRecipient`, etc.) to `ProfileDirectMessageHelper`.
+**Rationale:** Keeps the main controller focused on orchestration rather than utility logic.
+
+### 4. Move Rendering Logic
+**Decision:** Moved rendering methods (`renderAttachmentQueue`, `setMessagesUnreadIndicator`) to `ProfileDirectMessageRenderer`.
+**Rationale:** Separates DOM manipulation from business logic.
+
+### 5. Move Action Logic
+**Decision:** Moved action handlers (`handleSendDmRequest`, `handleSendProfileMessage`, etc.) to `ProfileDirectMessageActions`.
+**Rationale:** Groups user interaction handlers together.
+
+## Impact
+- `js/ui/profileModalController.js`: Reduced by ~405 lines.
+- Improved separation of concerns for Direct Messages within the Profile Modal.

--- a/docs/agents/task-logs/daily/2026-02-16_09-38-00_decompose-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_09-38-00_decompose-agent_completed.md
@@ -1,0 +1,1 @@
+Task completed. Decomposed `js/ui/profileModalController.js` by extracting Direct Message logic into sub-controllers.

--- a/test_logs/TEST_LOG_1771241005.md
+++ b/test_logs/TEST_LOG_1771241005.md
@@ -1,0 +1,31 @@
+# Test Log
+
+**Date:** 2026-02-16
+**Agent:** bitvid-decompose-agent
+**Target:** `js/ui/profileModalController.js`
+
+## Verification Steps
+
+### 1. Linting
+Command: `npm run lint`
+Result: Passed (minor non-blocking issues in other files)
+
+### 2. Unit Tests
+Command: `node scripts/run-targeted-tests.mjs tests/profile-modal-controller.test.mjs`
+Result: 18/18 tests passed.
+
+Command: `npm run test:unit`
+Result: All unit tests passed.
+
+### 3. File Size Check
+Command: `node scripts/check-file-size.mjs --report`
+Result: `js/ui/profileModalController.js` reduced from 6258 lines to 5853 lines (405 lines removed).
+
+## Manual Verification
+- Verified that DM logic was correctly moved to:
+  - `js/ui/profileModal/ProfileDirectMessageHelper.js`
+  - `js/ui/profileModal/ProfileDirectMessageActions.js`
+  - `js/ui/profileModal/ProfileDirectMessageRenderer.js`
+  - `js/ui/profileModal/ProfileDmRelayController.js`
+  - `js/ui/profileModal/ProfileDmAttachmentController.js`
+- Verified that `ProfileModalController` correctly delegates to these new controllers.


### PR DESCRIPTION
Extracted Direct Message logic from `js/ui/profileModalController.js` into:
- `js/ui/profileModal/ProfileDirectMessageHelper.js`
- `js/ui/profileModal/ProfileDirectMessageActions.js`
- `js/ui/profileModal/ProfileDirectMessageRenderer.js`
- `js/ui/profileModal/ProfileDmRelayController.js`
- `js/ui/profileModal/ProfileDmAttachmentController.js`

Reduced `ProfileModalController.js` size by ~405 lines. Verified with unit tests.

---
*PR created automatically by Jules for task [11165580605137552753](https://jules.google.com/task/11165580605137552753) started by @PR0M3TH3AN*