### PR TITLE
docs(ai): daily docs-agent run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,28 +99,10 @@ To set up the project locally:
    - **NPM**: v10 or higher (included with Node 22).
 
 2. **Install Dependencies**:
-   Use `npm ci` to ensure you get the exact dependencies from `package-lock.json`. If you intend to run smoke or visual tests, also install Playwright browsers.
+   Use `npm ci` to ensure you get the exact dependencies from `package-lock.json`. If you intend to run smoke, visual, or end-to-end tests, also install Playwright browsers.
 
    ```bash
    npm ci
-   npx playwright install
-   ```
-
-   If you plan to run visual or smoke tests, install the Playwright browsers:
-
-   ```bash
-   npx playwright install
-   ```
-
-   If you plan to run smoke tests or visual tests, install the Playwright browsers:
-
-   ```bash
-   npx playwright install
-   ```
-
-   If you plan to run smoke, visual, or end-to-end tests, install the Playwright browsers:
-
-   ```bash
    npx playwright install
    ```
 
@@ -160,7 +142,7 @@ To set up the project locally:
 
    ```bash
    npm run test:e2e
-   npm run test:smoke
+   npm run test:smoke   # Critical path verification
    npm run test:visual
    ```
 
@@ -181,12 +163,6 @@ To set up the project locally:
    ```bash
    npm run test:dm:unit
    npm run test:dm:integration
-   ```
-
-   To run smoke tests (critical path verification):
-
-   ```bash
-   npm run test:smoke
    ```
 
    To aggregate telemetry from test logs:

--- a/README.md
+++ b/README.md
@@ -143,28 +143,10 @@ To run **bitvid** locally:
 
 2. Install dependencies:
 
-   Use `npm ci` to install dependencies exactly as specified in `package-lock.json`. If you intend to run smoke or visual tests, also install Playwright browsers.
+   Use `npm ci` to install dependencies exactly as specified in `package-lock.json`. If you intend to run smoke, visual, or end-to-end tests, also install Playwright browsers.
 
    ```bash
    npm ci
-   npx playwright install
-   ```
-
-   If you plan to run visual or smoke tests, install the Playwright browsers:
-
-   ```bash
-   npx playwright install
-   ```
-
-   If you plan to run smoke tests or visual tests, install the Playwright browsers:
-
-   ```bash
-   npx playwright install
-   ```
-
-   If you plan to run smoke, visual, or end-to-end tests, install the Playwright browsers:
-
-   ```bash
    npx playwright install
    ```
 
@@ -227,14 +209,13 @@ For detailed architecture and system documentation, see the [Documentation Index
 
 **Other commands:**
 
-- **Run smoke tests**: `npm run test:smoke`
+- **Run smoke tests**: `npm run test:smoke` (Critical path verification)
 - **Run load tests**: `npm run test:load`
 - **Run DM unit tests**: `npm run test:dm:unit`
 - **Run DM integration tests**: `npm run test:dm:integration`
 - **Run headless E2E tests**: `npm run test:e2e`
 - **Run visual regression tests**: `npm run test:visual`
 - **Update visual baselines**: `npm run test:visual:update`
-- **Run smoke tests**: `npm run test:smoke` (Critical path verification)
 - **Run design system audit**: `npm run audit` (Generates remediation report)
 - **Aggregate telemetry**: `npm run telemetry:aggregate`
 - **Cancel CI runs**: See [`docs/cancelling-ci-runs.md`](docs/cancelling-ci-runs.md) for a script to clear pending workflows.

--- a/docs/agents/task-logs/daily/2026-02-16_13-05-00_docs-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_13-05-00_docs-agent_completed.md
@@ -1,0 +1,13 @@
+# docs-agent Task Log
+
+- **Date**: 2026-02-16
+- **Agent**: docs-agent
+- **Status**: Completed
+- **Cadence**: Daily
+
+## Activities
+- Audited `README.md` and `CONTRIBUTING.md` for duplicate instructions.
+- Removed redundant `npx playwright install` commands.
+- Consolidated installation instructions.
+- Removed redundant `npm run test:smoke` entries and clarified existing ones.
+- Verified changes with `npm run lint` and `npm run format`.


### PR DESCRIPTION
This PR runs the daily `docs-agent` task.

Changes:
- Removed duplicate `npx playwright install` commands in `README.md` and `CONTRIBUTING.md`.
- Consolidated "Install Dependencies" sections.
- Removed redundant `npm run test:smoke` entries and clarified existing ones with comments.
- Added daily task log: `docs/agents/task-logs/daily/2026-02-16_13-05-00_docs-agent_completed.md`.

---
*PR created automatically by Jules for task [12197791514898054474](https://jules.google.com/task/12197791514898054474) started by @PR0M3TH3AN*