### PR TITLE
🔒 security: use CSPRNG for deduplication tag generation

### DIFF
--- a/js/nostrEventSchemas.js
+++ b/js/nostrEventSchemas.js
@@ -740,6 +740,24 @@ export function getAllNostrEventSchemas() {
   return entries;
 }
 
+function generateRandomIdentifier() {
+  if (
+    typeof globalThis.crypto !== "undefined" &&
+    typeof globalThis.crypto.randomUUID === "function"
+  ) {
+    return globalThis.crypto.randomUUID();
+  }
+  if (
+    typeof globalThis.crypto !== "undefined" &&
+    typeof globalThis.crypto.getRandomValues === "function"
+  ) {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}
+
 function appendSchemaTags(tags, schema) {
   if (!Array.isArray(schema?.appendTags)) {
     return tags;
@@ -1834,9 +1852,7 @@ export function buildViewEvent(params) {
 
   const resolvedDedupeTag =
     dedupeTag ||
-    (schema?.identifierTag?.name
-      ? Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)
-      : "");
+    (schema?.identifierTag?.name ? generateRandomIdentifier() : "");
 
   if (resolvedDedupeTag && schema?.identifierTag?.name) {
     const identifierName = schema.identifierTag.name;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR replaces the insecure `Math.random()` usage for generating deduplication tags in `js/nostrEventSchemas.js` with a cryptographically secure approach.

⚠️ **Risk:** The potential impact if left unfixed
Using `Math.random()` can lead to predictable random values and collisions. In the context of deduplication tags, this could result in events being incorrectly discarded or failing to deduplicate, potentially causing data inconsistency or UX issues.

🛡️ **Solution:** How the fix addresses the vulnerability
A new helper function `generateRandomIdentifier()` was added to `js/nostrEventSchemas.js`. This function prioritizes:
1. `globalThis.crypto.randomUUID()` (CSPRNG, standard UUID)
2. `globalThis.crypto.getRandomValues()` (CSPRNG, hex string)
3. `Math.random()` (only as a last resort fallback if no secure API is available)

The `buildViewEvent` function was updated to use this helper for generating its default deduplication tag.

---
*PR created automatically by Jules for task [6911140361540334008](https://jules.google.com/task/6911140361540334008) started by @PR0M3TH3AN*