### PR TITLE
Load Test Agent: Add Resource Metrics and Defaults

### DIFF
--- a/docs/agents/task-logs/daily/2026-02-16_20-50-00_load-test-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_20-50-00_load-test-agent_completed.md
@@ -1,0 +1,30 @@
+# Daily Task: Load Test Agent
+
+**Date:** 2026-02-16
+**Agent:** bitvid-load-test-agent
+**Status:** Completed
+
+## Summary
+Updated `scripts/agent/load-test.mjs` to meet safety and reporting requirements:
+- Increased default `CLIENTS` to 1000 (from 50).
+- Added resource usage monitoring (RSS memory, CPU user/system time).
+- Included resource metrics in the final JSON report.
+- Verified safety checks (requires `RELAY_URL` or starts local relay, detects public IPs).
+
+## Test Run Results
+Executed a 60-second load test with 1000 clients and 50 events/second.
+
+- **Throughput:** ~44 events/sec (Target: 50).
+- **Latency:** Avg 1.5ms, p99 22ms.
+- **Resource Usage:** RSS stable around 115MB. CPU usage moderate.
+- **Errors:** 0 errors, 0 rejected events.
+
+The harness is functional and capable of generating sustained load against a local relay.
+
+## Artifacts
+- `scripts/agent/load-test.mjs` (Updated)
+- `artifacts/load-report-20260216.json` (Generated)
+
+## Recommendations
+1. **Bottleneck Investigation:** Throughput slightly lagged behind the target rate (44 vs 50 EPS). This may be due to single-threaded event loop saturation in the test script itself or the local relay. Future work could shard the load generator.
+2. **Resource Baseline:** Memory usage is low (~120MB) for 1000 idle clients. Scaling to 10k clients should be feasible on standard hardware.


### PR DESCRIPTION
Updated `scripts/agent/load-test.mjs` to include resource usage monitoring (memory, CPU) and increased default client count to 1000. Verified the harness with a 60-second load test against a local relay. Generated a load report in `artifacts/load-report-20260216.json` and a completion log in `docs/agents/task-logs/daily/`.

---
*PR created automatically by Jules for task [12413052645096947240](https://jules.google.com/task/12413052645096947240) started by @PR0M3TH3AN*