### PR TITLE
docs: add failed daily agent log

### DIFF
--- a/docs/agents/task-logs/daily/2026-02-16_23-32-36_known-issues-agent_failed.md
+++ b/docs/agents/task-logs/daily/2026-02-16_23-32-36_known-issues-agent_failed.md
@@ -1,0 +1,1 @@
+Nostr relay error


### PR DESCRIPTION
Added a failed log file for `known-issues-agent` as the scheduler encountered a Nostr relay error during the lock acquisition process. This follows the protocol defined in `docs/agents/prompts/scheduler-flow.md`.

---
*PR created automatically by Jules for task [11028473681185358841](https://jules.google.com/task/11028473681185358841) started by @PR0M3TH3AN*