### PR TITLE
[security] innerHTML migration for js/historyView.js

### DIFF
--- a/docs/agents/task-logs/daily/2026-02-17_00-44-39_innerhtml-migration-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-17_00-44-39_innerhtml-migration-agent_completed.md
@@ -1,0 +1,1 @@
+Successfully migrated 4 innerHTML assignments in `js/historyView.js` to `replaceChildren()`. Updated baseline.

--- a/js/historyView.js
+++ b/js/historyView.js
@@ -1782,7 +1782,7 @@ export function createWatchHistoryRenderer(config = {}) {
 
   function showEmptyState() {
     if (elements.grid) {
-      elements.grid.innerHTML = "";
+      elements.grid.replaceChildren();
       setHidden(elements.grid, true);
     }
     clearHistoryCardRegistry();
@@ -1806,7 +1806,7 @@ export function createWatchHistoryRenderer(config = {}) {
     }
     detachObserver();
     if (elements.grid) {
-      elements.grid.innerHTML = "";
+      elements.grid.replaceChildren();
       setHidden(elements.grid, true);
     }
     if (elements.empty) {
@@ -2304,7 +2304,7 @@ export function createWatchHistoryRenderer(config = {}) {
     }
     state.cursor = 0;
     state.hasMore = state.items.length > 0;
-    elements.grid.innerHTML = "";
+    elements.grid.replaceChildren();
     clearHistoryCardRegistry();
     removeEmptyDayContainers(elements.grid);
     if (!state.items.length) {
@@ -2427,7 +2427,7 @@ export function createWatchHistoryRenderer(config = {}) {
       }
       clearSubscriptions();
       if (elements.grid) {
-        elements.grid.innerHTML = "";
+        elements.grid.replaceChildren();
       }
       clearHistoryCardRegistry();
       state.initialized = false;

--- a/scripts/check-innerhtml.mjs
+++ b/scripts/check-innerhtml.mjs
@@ -27,7 +27,6 @@ const BASELINE = {
   "js/docsView.js": 1,
   "js/exploreView.js": 1,
   "js/forYouView.js": 1,
-  "js/historyView.js": 4,
   "js/index.js": 1,
   "js/kidsView.js": 1,
   "js/ui/components/DeleteModal.js": 3,


### PR DESCRIPTION
Replaced 4 instances of `innerHTML = ""` with `replaceChildren()` in `js/historyView.js`. This reduces the tracked innerHTML usage count for this file to 0. Updated `scripts/check-innerhtml.mjs` baseline to reflect this change.

Also included agent artifacts in `artifacts/innerhtml-migration/` and completion log in `docs/agents/task-logs/daily/`.

---
*PR created automatically by Jules for task [8669158924862950135](https://jules.google.com/task/8669158924862950135) started by @PR0M3TH3AN*