### PR TITLE
refactor: remove unused imports in js/userBlocks.js

### DIFF
--- a/js/userBlocks.js
+++ b/js/userBlocks.js
@@ -5,14 +5,12 @@ import {
 } from "./nostrClientFacade.js";
 import { getActiveSigner } from "./nostr/index.js";
 import { isSessionActor } from "./nostr/sessionActor.js";
-import { normalizeNostrPubkey } from "./nostr/nip46Client.js";
 import {
   buildBlockListEvent,
   buildMuteListEvent,
   BLOCK_LIST_IDENTIFIER,
   KIND_MUTE_LIST,
 } from "./nostrEventSchemas.js";
-import { CACHE_POLICIES, STORAGE_TIERS } from "./nostr/cachePolicies.js";
 import { devLogger, userLogger } from "./utils/logger.js";
 import { STANDARD_TIMEOUT_MS, MAX_BLOCKLIST_ENTRIES } from "./constants.js";
 import {


### PR DESCRIPTION
Removes unused imports `normalizeNostrPubkey`, `CACHE_POLICIES`, and `STORAGE_TIERS` from `js/userBlocks.js` to improve code cleanliness.

This change does not affect functionality as these imports were not used in the file.
Verified with lint checks and by running `tests/user-blocks.test.mjs` (which has a known unrelated failure).

---
*PR created automatically by Jules for task [17607444837485158820](https://jules.google.com/task/17607444837485158820) started by @PR0M3TH3AN*