### PR TITLE
🧹 Remove unused imports in js/relayManager.js

### DIFF
--- a/js/relayManager.js
+++ b/js/relayManager.js
@@ -5,8 +5,7 @@ import {
   requestDefaultExtensionPermissions,
 } from "./nostrClientFacade.js";
 import { getActiveSigner } from "./nostr/index.js";
-import { buildRelayListEvent, NOTE_TYPES } from "./nostrEventSchemas.js";
-import { CACHE_POLICIES, STORAGE_TIERS } from "./nostr/cachePolicies.js";
+import { buildRelayListEvent } from "./nostrEventSchemas.js";
 import { devLogger, userLogger } from "./utils/logger.js";
 import {
   publishEventToRelays,


### PR DESCRIPTION
Removed unused imports (`NOTE_TYPES`, `CACHE_POLICIES`, `STORAGE_TIERS`) from `js/relayManager.js` to improve code cleanliness. Verified changes by running relevant tests (`tests/compliance/nip65_compliance.test.mjs`, `tests/subscriptions-manager.test.mjs`, `tests/hashtag-preferences.test.mjs`) and lint checks.

---
*PR created automatically by Jules for task [16315605028044004390](https://jules.google.com/task/16315605028044004390) started by @PR0M3TH3AN*