### PR TITLE
chore: remove unused imports in js/app.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -25,8 +25,6 @@ import {
   DEFAULT_TRUSTED_SPAM_HIDE_THRESHOLD,
   FEED_TYPES,
 } from "./constants.js";
-import { attachHealthBadges } from "./gridHealth.js";
-import { attachUrlHealthBadges } from "./urlHealthObserver.js";
 import { updateVideoCardSourceVisibility } from "./utils/cardSourceVisibility.js";
 import { collectVideoTags } from "./utils/videoTags.js";
 import { normalizeHashtag } from "./utils/hashtagNormalization.js";


### PR DESCRIPTION
Removed unused imports `attachHealthBadges` and `attachUrlHealthBadges` from `js/app.js`.

These imports were identified as unused in the file. Removing them improves code cleanliness.

Ran `npm run lint` and `npm run test:unit` to verify no regressions. `npm run build` also passed.

---
*PR created automatically by Jules for task [14740380868403536540](https://jules.google.com/task/14740380868403536540) started by @PR0M3TH3AN*