### PR TITLE
docs(agents): sync scheduler rosters with prompt directory

### DIFF
--- a/context/CONTEXT_2026-02-17_14-32-50.md
+++ b/context/CONTEXT_2026-02-17_14-32-50.md
@@ -1,0 +1,4 @@
+# Context
+- Goal: Sync scheduler rosters with prompt directories.
+- Scope: `docs/agents/prompts/daily/` and `docs/agents/prompts/weekly/`.
+- Status: Initial check complete. Rosters match files on disk.

--- a/decisions/DECISIONS_2026-02-17_14-32-50.md
+++ b/decisions/DECISIONS_2026-02-17_14-32-50.md
@@ -1,0 +1,2 @@
+# Decisions
+- No changes made to scheduler files because rosters matched the file inventory exactly.

--- a/docs/agents/task-logs/daily/2026-02-17_14-32-50_scheduler-update-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-17_14-32-50_scheduler-update-agent_completed.md
@@ -1,0 +1,5 @@
+# Scheduler Update Agent - Completed
+
+- Date: 2026-02-17
+- Status: Success
+- Output: Rosters already in sync. No changes applied.

--- a/test_logs/TEST_LOG_2026-02-17_14-32-50.md
+++ b/test_logs/TEST_LOG_2026-02-17_14-32-50.md
@@ -1,0 +1,5 @@
+# Verification Log
+- Checked daily prompts: 21 files found.
+- Checked daily roster: 21 entries found. Match.
+- Checked weekly prompts: 16 files found.
+- Checked weekly roster: 16 entries found. Match.

--- a/todo/TODO_2026-02-17_14-32-50.md
+++ b/todo/TODO_2026-02-17_14-32-50.md
@@ -1,0 +1,9 @@
+# Tasks
+- [x] Preflight checks
+- [x] Inventory daily prompts
+- [x] Inventory weekly prompts
+- [x] Read current rosters
+- [x] Diff daily
+- [x] Diff weekly
+- [x] Verify (no changes needed)
+- [ ] Document and complete


### PR DESCRIPTION
Executed the `bitvid-scheduler-update-agent` to ensure that the daily and weekly scheduler rosters in `docs/agents/prompts/` are synchronized with the actual prompt files on disk.

- Performed a diff between the file system and the markdown rosters.
- Confirmed that all 21 daily agents and 16 weekly agents are correctly listed.
- Created persistent state files (`context/`, `todo/`, `decisions/`, `test_logs/`) documenting the run and verification results.
- Created a completion log in `docs/agents/task-logs/daily/`.

---
*PR created automatically by Jules for task [3004915157012610391](https://jules.google.com/task/3004915157012610391) started by @PR0M3TH3AN*