### PR TITLE
Refactor constant timeouts in subscriptions and userBlocks

### DIFF
--- a/context/CONTEXT_20260217_205312.md
+++ b/context/CONTEXT_20260217_205312.md
@@ -1,0 +1,1 @@
+# Context for Constants Refactor\n\nTimestamp: 20260217_205312\nBranch: unstable\nCommit: 65d82e578faf6c46ee7d2b6c61d93105c6f4c855\nNode: v22.22.0\nNPM: 11.7.0\n\nGoal: Find duplicated numeric constants in js/ and replace with canonical definitions.

--- a/decisions/DECISIONS_20260217_205312.md
+++ b/decisions/DECISIONS_20260217_205312.md
@@ -1,0 +1,7 @@
+# Decisions for Constants Refactor
+
+- **5000ms timeout in `js/subscriptions.js`**: Replaced with `SHORT_TIMEOUT_MS` from `js/constants.js`. The usage matches the definition of a "short timeout" for background operations or quick fallbacks.
+- **10000ms timeout in `js/userBlocks.js`**: Replaced with `STANDARD_TIMEOUT_MS` from `js/constants.js`. The usage is for a fetch operation which aligns with the standard timeout definition.
+
+Alternatives considered:
+- Creating specific constants like `NIP07_SHORT_TIMEOUT_MS`. Rejected because `SHORT_TIMEOUT_MS` is generic enough and already used for similar purposes.

--- a/docs/agents/task-logs/daily/2026-02-17_20-53-12_const-refactor-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-17_20-53-12_const-refactor-agent_completed.md
@@ -1,0 +1,19 @@
+# Agent Run: const-refactor-agent
+
+**Status:** Completed
+**Timestamp:** 2026-02-17 20:53:12
+**Agent:** const-refactor-agent
+**Cadence:** daily
+
+## Summary
+Replaced duplicated numeric constants with canonical definitions.
+
+- Replaced `5000` with `SHORT_TIMEOUT_MS` in `js/subscriptions.js`.
+- Replaced `timeoutMs: 10000` with `timeoutMs: STANDARD_TIMEOUT_MS` in `js/userBlocks.js`.
+
+## Artifacts
+- `context/CONTEXT_20260217_205312.md`
+- `todo/TODO_20260217_205312.md`
+- `decisions/DECISIONS_20260217_205312.md`
+- `test_logs/TEST_LOG_20260217_205312.md`
+- `perf/constants-refactor/candidates.json`

--- a/js/subscriptions.js
+++ b/js/subscriptions.js
@@ -26,6 +26,7 @@ import {
 import { getApplication } from "./applicationContext.js";
 import { VideoListView } from "./ui/views/VideoListView.js";
 import { ALLOW_NSFW_CONTENT } from "./config.js";
+import { SHORT_TIMEOUT_MS } from "./constants.js";
 import { devLogger, userLogger } from "./utils/logger.js";
 import moderationService from "./services/moderationService.js";
 import nostrService from "./services/nostrService.js";
@@ -1093,7 +1094,7 @@ class SubscriptionsManager {
     // gate now guarantees the extension is ready before decryption starts, so
     // decrypt calls should complete within 1-2s. 5s accommodates slow
     // extensions while still failing fast enough for scheme fallback.
-    const nip07DecryptTimeoutMs = allowPermissionPrompt ? 12000 : 5000;
+    const nip07DecryptTimeoutMs = allowPermissionPrompt ? 12000 : SHORT_TIMEOUT_MS;
     const signerDecryptOptions = {
       priority: NIP07_PRIORITY.NORMAL,
       timeoutMs: nip07DecryptTimeoutMs,

--- a/js/userBlocks.js
+++ b/js/userBlocks.js
@@ -1558,7 +1558,7 @@ class UserBlockListManager {
         pubkey: normalized,
         relayUrls: relays,
         since: fetchSince,
-        timeoutMs: 10000,
+        timeoutMs: STANDARD_TIMEOUT_MS,
       });
 
       const legacyFetchPromise = Promise.all([

--- a/perf/constants-refactor/candidates.json
+++ b/perf/constants-refactor/candidates.json
@@ -1,5 +1,13 @@
 [
   {
+    "value": 5000,
+    "semantic": "short timeout",
+    "occurrences": [
+      { "file": "js/subscriptions.js", "line": 1096, "context": "nip07DecryptTimeoutMs" }
+    ],
+    "canonical": { "name": "SHORT_TIMEOUT_MS", "file": "js/constants.js" }
+  },
+  {
     "value": 10000,
     "semantic": "STANDARD_TIMEOUT_MS",
     "occurrences": [
@@ -7,7 +15,9 @@
       {"file": "js/nostr/relayBatchFetcher.js", "line": 19, "context": "timeoutMs = 10000"},
       {"file": "js/nostr/relayBatchFetcher.js", "line": 135, "context": "timeoutMs : 10000"},
       {"file": "js/nostr/client.js", "line": 812, "context": "timeoutMs = 10000"},
-      {"file": "js/nostr/client.js", "line": 1425, "context": "timeoutMs || 10000"}
-    ]
+      {"file": "js/nostr/client.js", "line": 1425, "context": "timeoutMs || 10000"},
+      { "file": "js/userBlocks.js", "line": 1561, "context": "timeoutMs" }
+    ],
+    "canonical": { "name": "STANDARD_TIMEOUT_MS", "file": "js/constants.js" }
   }
 ]

--- a/test_logs/TEST_LOG_20260217_205312.md
+++ b/test_logs/TEST_LOG_20260217_205312.md
@@ -1,0 +1,7 @@
+# Test Log
+
+## Lint
+Passed.
+
+## Unit Tests
+Passed. All unit tests executed successfully.

--- a/todo/TODO_20260217_205312.md
+++ b/todo/TODO_20260217_205312.md
@@ -1,0 +1,6 @@
+# TODO List for Constants Refactor
+
+- [x] Identify duplicates for 5000ms (SHORT_TIMEOUT_MS) in js/subscriptions.js
+- [x] Identify duplicates for 10000ms (STANDARD_TIMEOUT_MS) in js/userBlocks.js
+- [x] Replace with canonical constants
+- [x] Verify with lint and tests


### PR DESCRIPTION
Scheduler run for `const-refactor-agent`.
Replaced duplicate 5000ms and 10000ms timeouts with canonical constants in `js/subscriptions.js` and `js/userBlocks.js`.
Restored and updated `perf/constants-refactor/candidates.json` to include previous and new findings.
Verified imports in modified files.

---
*PR created automatically by Jules for task [13915779622347863588](https://jules.google.com/task/13915779622347863588) started by @PR0M3TH3AN*