### PR TITLE
[weekly] frontend-console-debug-agent: fix broken tracker

### DIFF
--- a/docs/agents/task-logs/weekly/2026-02-18_01-10-14_frontend-console-debug-agent_completed.md
+++ b/docs/agents/task-logs/weekly/2026-02-18_01-10-14_frontend-console-debug-agent_completed.md
@@ -1,0 +1,10 @@
+# Agent Run: frontend-console-debug-agent
+
+- **Date:** 2026-02-18
+- **Status:** Completed
+- **Changes:**
+  - Removed `wss://tracker.btorrent.xyz` from `js/constants.js` (caused `net::ERR_CERT_COMMON_NAME_INVALID` on initialization).
+  - Updated `scripts/agent/debug_frontend.py` to target port 3000 (default `npx serve` port) instead of 8000.
+- **Verification:**
+  - Ran `python3 scripts/agent/debug_frontend.py`: Error count dropped from 5 to 4 (removed the blocking initialization error). Remaining errors are content-specific CORS/404s.
+  - Ran `npm run test:unit:shard1`: Passed.

--- a/js/constants.js
+++ b/js/constants.js
@@ -138,7 +138,6 @@ function sanitizeTrustSeedList(candidate) {
 const DEFAULT_WSS_TRACKERS = Object.freeze([
   "wss://tracker.openwebtorrent.com",
   "wss://tracker.files.fm:7073/announce",
-  "wss://tracker.btorrent.xyz",
   "wss://tracker.novage.com.ua:443/announce",
   "wss://tracker.webtorrent.dev",
 ]);

--- a/scripts/agent/debug_frontend.py
+++ b/scripts/agent/debug_frontend.py
@@ -38,8 +38,8 @@ def run():
         page.on("requestfailed", on_request_failed)
 
         try:
-            log("INFO", "Navigating to http://localhost:8000...")
-            page.goto("http://localhost:8000")
+            log("INFO", "Navigating to http://localhost:3000...")
+            page.goto("http://localhost:3000")
 
             # Wait for load state to ensure initial resources are loaded
             try:


### PR DESCRIPTION
Removed `wss://tracker.btorrent.xyz` from `js/constants.js` as it causes `net::ERR_CERT_COMMON_NAME_INVALID` on initialization. Updated `scripts/agent/debug_frontend.py` to use correct port 3000. Verified with Playwright capture script.

---
*PR created automatically by Jules for task [5469852811724557248](https://jules.google.com/task/5469852811724557248) started by @PR0M3TH3AN*