### PR TITLE
[security] replace innerHTML usages in js/ui/components/DeleteModal.js

### DIFF
--- a/decisions/DECISIONS_2026-02-18_15-05-00.md
+++ b/decisions/DECISIONS_2026-02-18_15-05-00.md
@@ -1,0 +1,13 @@
+# Decisions - 2026-02-18
+
+File: `js/ui/components/DeleteModal.js`
+
+1.  **Template Loading (Line 108)**:
+    - **Before**: `wrapper.innerHTML = html`
+    - **After**: `const doc = new DOMParser().parseFromString(html, 'text/html'); wrapper.append(...doc.body.children);`
+    - **Rationale**: While the source is a local file (`components/delete-video-modal.html`), using `DOMParser` prevents execution of scripts by default and avoids raw HTML injection vulnerabilities if the template were ever compromised or modified. It aligns with the goal of removing `innerHTML`.
+
+2.  **Clearing List (Line 263 & 368)**:
+    - **Before**: `this.metadataList.innerHTML = ""`
+    - **After**: `this.metadataList.replaceChildren()`
+    - **Rationale**: `replaceChildren()` is the modern, performant way to empty an element. `textContent = ""` is also valid but `replaceChildren()` is explicitly for manipulating child nodes.

--- a/docs/agents/task-logs/daily/2026-02-18_15-15-00_innerhtml-migration-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-18_15-15-00_innerhtml-migration-agent_completed.md
@@ -1,0 +1,14 @@
+# Task Completion Log: innerhtml-migration-agent
+
+- **Date**: 2026-02-18
+- **Agent**: innerhtml-migration-agent (via daily scheduler)
+- **Status**: Completed
+- **Changes**:
+  - Migrated `js/ui/components/DeleteModal.js` to safe DOM APIs.
+  - Reduced `innerHTML` count by 3 (from 3 to 0).
+  - Updated `scripts/check-innerhtml.mjs` baseline.
+- **Artifacts**:
+  - `context/CONTEXT_2026-02-18_15-00-00.md`
+  - `todo/TODO_2026-02-18_15-05-00.md`
+  - `decisions/DECISIONS_2026-02-18_15-05-00.md`
+  - `perf/innerhtml/raw-report-2026-02-18.log`

--- a/js/ui/components/DeleteModal.js
+++ b/js/ui/components/DeleteModal.js
@@ -108,7 +108,8 @@ export class DeleteModal {
 
       const html = await response.text();
       const wrapper = document.createElement("div");
-      wrapper.innerHTML = html;
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      wrapper.append(...doc.body.children);
       this.removeTrackingScripts(wrapper);
       targetContainer.appendChild(wrapper);
       modal = wrapper.querySelector("#deleteVideoModal");
@@ -263,7 +264,7 @@ export class DeleteModal {
     }
 
     const doc = this.metadataList.ownerDocument;
-    this.metadataList.innerHTML = "";
+    this.metadataList.replaceChildren();
     if (!doc) {
       return;
     }
@@ -421,7 +422,7 @@ export class DeleteModal {
     }
 
     if (this.metadataList) {
-      this.metadataList.innerHTML = "";
+      this.metadataList.replaceChildren();
     }
   }
 

--- a/scripts/check-innerhtml.mjs
+++ b/scripts/check-innerhtml.mjs
@@ -29,7 +29,6 @@ const BASELINE = {
   "js/forYouView.js": 1,
   "js/index.js": 1,
   "js/kidsView.js": 1,
-  "js/ui/components/DeleteModal.js": 3,
   "js/ui/components/EditModal.js": 1,
   "js/ui/components/EmbedVideoModal.js": 1,
   "js/ui/components/EventDetailsModal.js": 1,

--- a/todo/TODO_2026-02-18_15-05-00.md
+++ b/todo/TODO_2026-02-18_15-05-00.md
@@ -1,0 +1,13 @@
+# TODO - 2026-02-18
+
+File: `js/ui/components/DeleteModal.js`
+
+1.  **Line 108**: `wrapper.innerHTML = html;`
+    - Context: Loading `components/delete-video-modal.html` template.
+    - Strategy: Use `DOMParser` to parse the HTML string and append children to wrapper.
+2.  **Line 263**: `this.metadataList.innerHTML = "";`
+    - Context: Clearing the metadata list before re-rendering.
+    - Strategy: Replace with `this.metadataList.replaceChildren()` or `this.metadataList.textContent = ""`.
+3.  **Line 368**: `this.metadataList.innerHTML = "";`
+    - Context: Resetting the modal state.
+    - Strategy: Replace with `this.metadataList.replaceChildren()`.


### PR DESCRIPTION
This PR migrates `innerHTML` usage in `js/ui/components/DeleteModal.js` to safer DOM APIs as part of the daily `innerhtml-migration-agent` task.

Changes:
- Uses `DOMParser` to parse the delete modal template instead of assigning to `innerHTML`.
- Uses `replaceChildren()` to clear the metadata list.
- Updates the baseline in `scripts/check-innerhtml.mjs`.

Verification:
- `npm run lint` passed.
- `npm run test:unit` passed.
- `scripts/check-innerhtml.mjs` report confirms reduced usage.

---
*PR created automatically by Jules for task [17298730547191079661](https://jules.google.com/task/17298730547191079661) started by @PR0M3TH3AN*