### PR TITLE
docs(agents): sync scheduler rosters with prompt directory

### DIFF
--- a/context/CONTEXT_2026-02-18_19-45-00.md
+++ b/context/CONTEXT_2026-02-18_19-45-00.md
@@ -1,0 +1,13 @@
+# Scheduler Update Context
+
+**Goal**: Sync `daily-scheduler.md` and `weekly-scheduler.md` rosters with the actual prompt files in `docs/agents/prompts/daily/` and `docs/agents/prompts/weekly/`.
+
+**Scope**:
+- Read prompt directories.
+- Read scheduler files.
+- Verify sync status.
+- Update if necessary.
+
+**Assumptions**:
+- Files are named `bitvid-<agent-name>.md`.
+- Scheduler files use a specific markdown table format.

--- a/decisions/DECISIONS_2026-02-18_19-45-00.md
+++ b/decisions/DECISIONS_2026-02-18_19-45-00.md
@@ -1,0 +1,3 @@
+# Scheduler Update Decisions
+
+- None yet.

--- a/docs/agents/task-logs/daily/2026-02-18_19-48-00_scheduler-update-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-18_19-48-00_scheduler-update-agent_completed.md
@@ -1,0 +1,24 @@
+# Scheduler Update Agent Completion Log
+
+**Agent**: scheduler-update-agent
+**Date**: 2026-02-18
+**Time**: 19:48:00 UTC
+**Result**: Success
+
+## Summary
+
+The `scheduler-update-agent` executed successfully. Both daily and weekly scheduler rosters were verified against the prompt directories.
+
+## Verification
+
+- **Daily Roster**: 21 files on disk, 21 rows in scheduler. (SYNCED)
+- **Weekly Roster**: 16 files on disk, 16 rows in scheduler. (SYNCED)
+
+No changes were required to the scheduler files.
+
+## Artifacts
+
+- `test_logs/TEST_LOG_2026-02-18_19-45-00.md`: Verification details.
+- `context/CONTEXT_2026-02-18_19-45-00.md`: Agent context.
+- `todo/TODO_2026-02-18_19-45-00.md`: Agent todo list.
+- `decisions/DECISIONS_2026-02-18_19-45-00.md`: Agent decisions.

--- a/test_logs/TEST_LOG_2026-02-18_19-45-00.md
+++ b/test_logs/TEST_LOG_2026-02-18_19-45-00.md
@@ -1,0 +1,32 @@
+# Scheduler Update Verification Log
+
+**Date**: 2026-02-18
+**Time**: 19:45:00 UTC (Approx)
+**Agent**: scheduler-update-agent
+
+## Daily Roster Verification
+
+- **Files in `docs/agents/prompts/daily/`**: 21
+- **Rows in `docs/agents/prompts/daily-scheduler.md`**: 21
+- **Status**: SYNCED
+- **Details**:
+  - All files accounted for.
+  - Alphabetical order correct.
+  - Agent names derived correctly.
+
+## Weekly Roster Verification
+
+- **Files in `docs/agents/prompts/weekly/`**: 16
+- **Rows in `docs/agents/prompts/weekly-scheduler.md`**: 16
+- **Status**: SYNCED
+- **Details**:
+  - All files accounted for.
+  - Alphabetical order correct.
+  - Agent names derived correctly.
+
+## Actions Taken
+
+- Read file lists.
+- Read scheduler files.
+- Compared content.
+- No changes required.

--- a/todo/TODO_2026-02-18_19-45-00.md
+++ b/todo/TODO_2026-02-18_19-45-00.md
@@ -1,0 +1,6 @@
+# Scheduler Update TODO
+
+- [ ] Verify daily roster
+- [ ] Verify weekly roster
+- [ ] Update if needed
+- [ ] Verify lint


### PR DESCRIPTION
Executed scheduler-update-agent. Verified daily and weekly scheduler rosters against prompt directories. No changes were required as rosters were already in sync. Created task logs and context files.

---
*PR created automatically by Jules for task [4524945435922833583](https://jules.google.com/task/4524945435922833583) started by @PR0M3TH3AN*