### PR TITLE
chore(deps): deps-security-agent run & bump stylelint to 16.26.1

### DIFF
--- a/artifacts/deps-report.md
+++ b/artifacts/deps-report.md
@@ -1,17 +1,33 @@
-# Dependency Security Report (2026-02-19)
+# Dependency Report - 2026-02-20
 
 ## Vulnerabilities
-- **High**: 3 (minimatch, serve, serve-handler)
-- **Moderate**: 1 (ajv)
-- Note: 'serve' vulnerabilities relate to a known issue where the fix suggests a major downgrade. Ignoring as per policy.
+### HIGH (3)
+- **minimatch**: minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern
+  - Path: Direct dependency? No
+  - Fix Available: true
+- **serve**: ajv, serve-handler
+  - Path: Direct dependency? Yes
+  - Fix Available: {"name":"serve","version":"6.5.8","isSemVerMajor":true}
+- **serve-handler**: minimatch
+  - Path: Direct dependency? No
+  - Fix Available: true
+### MODERATE (1)
+- **ajv**: ajv has ReDoS when using `$data` option
 
 ## Outdated Packages
-- **nostr-tools**: 2.19.4 -> 2.23.1 (Security Sensitive - Skipped)
-- **jsdom**: 28.1.0 (Verified / Up-to-date)
-- **stylelint**: 16.12.0 -> 16.26.1
-- **tailwindcss**: 3.4.19 -> 4.1.18 (Major - Skipped)
-- **pixelmatch**: 5.3.0 -> 7.1.0 (Major - Skipped)
-- **postcss-import**: 15.1.0 -> 16.1.1 (Major - Skipped)
+### Major Updates (Risky)
+- **pixelmatch** (undefined): 5.3.0 -> 7.1.0
+- **postcss-import** (undefined): 15.1.0 -> 16.1.1
+- **prettier-plugin-tailwindcss** (undefined): 0.6.14 -> 0.7.2
+- **stylelint-config-standard** (undefined): 36.0.1 -> 40.0.0
+- **tailwindcss** (undefined): 3.4.19 -> 4.2.0
 
-## Actions
-- Verified `jsdom` is at 28.1.0 and tests pass.
+### Minor Updates (Safe-ish)
+- **nostr-tools** (undefined): 2.19.4 -> 2.23.1 (Latest: 2.23.1)
+- **stylelint** (undefined): 16.12.0 -> 16.26.1 (Latest: 17.3.0)
+
+### Patch Updates (Safe)
+
+## Triage & Actions
+- [ ] **HIGH**: Check for safe upgrades for minimatch, serve, serve-handler.
+- [ ] **Safe Candidates**: nostr-tools, stylelint

--- a/artifacts/npm-outdated.json
+++ b/artifacts/npm-outdated.json
@@ -1,11 +1,4 @@
 {
-  "jsdom": {
-    "current": "28.0.0",
-    "wanted": "28.1.0",
-    "latest": "28.1.0",
-    "dependent": "app",
-    "location": "/app/node_modules/jsdom"
-  },
   "nostr-tools": {
     "current": "2.19.4",
     "wanted": "2.23.1",
@@ -51,7 +44,7 @@
   "tailwindcss": {
     "current": "3.4.19",
     "wanted": "3.4.19",
-    "latest": "4.1.18",
+    "latest": "4.2.0",
     "dependent": "app",
     "location": "/app/node_modules/tailwindcss"
   }

--- a/context/CONTEXT_2026-02-20_14-39-21_deps-security-agent.md
+++ b/context/CONTEXT_2026-02-20_14-39-21_deps-security-agent.md
@@ -1,0 +1,5 @@
+# Context
+Date: Fri Feb 20 14:39:21 UTC 2026
+Package Manager: npm
+Node: v22.22.0
+CI Matrix: Standard

--- a/decisions/DECISIONS_2026-02-20_14-39-21_deps-security-agent.md
+++ b/decisions/DECISIONS_2026-02-20_14-39-21_deps-security-agent.md
@@ -1,0 +1,4 @@
+## Decisions
+- Upgraded stylelint to 16.26.1 (minor, safe dev dependency).
+- Skipped nostr-tools (requires review).
+- Created artifacts/deps-report.md.

--- a/docs/agents/task-logs/daily/2026-02-20_14-42-40_deps-security-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-20_14-42-40_deps-security-agent_completed.md
@@ -1,0 +1,20 @@
+# deps-security-agent Daily Run - 2026-02-20_14-42-40
+
+## Summary
+- Analyzed dependencies using `npm audit` and `npm outdated`.
+- Generated artifacts in `artifacts/deps-report.md`.
+- Upgraded `stylelint` (devDependency) to `16.26.1` (minor update).
+- Verified linting passed.
+
+## Artifacts
+- `artifacts/deps-report.md`
+- `artifacts/npm-audit.json`
+- `artifacts/npm-outdated.json`
+- `context/CONTEXT_2026-02-20_14-42-40_deps-security-agent.md`
+- `todo/TODO_2026-02-20_14-42-40_deps-security-agent.md`
+- `decisions/DECISIONS_2026-02-20_14-42-40_deps-security-agent.md`
+- `test_logs/TEST_LOG_2026-02-20_14-42-40_deps-security-agent.md`
+
+## Next Steps
+- Review `serve` vulnerabilities (moderate).
+- Consider manual upgrade for `nostr-tools` (pending maintainer review).

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.6.5",
         "serve": "^14.2.5",
-        "stylelint": "^16.12.0",
+        "stylelint": "^16.26.1",
         "stylelint-config-standard": "^36.0.1",
         "vitest": "^4.0.18"
       },
@@ -226,6 +226,30 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
+      "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.3.3",
+        "@keyv/bigmap": "^1.3.0",
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.4.tgz",
+      "integrity": "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.3.0",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -842,6 +866,30 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "0.5.3",
@@ -1866,6 +1914,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
+      "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.7",
+        "@cacheable/utils": "^2.3.3",
+        "hookified": "^1.15.0",
+        "keyv": "^5.5.5",
+        "qified": "^0.6.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2853,16 +2915,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/fill-range": {
@@ -2878,17 +2937,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "cacheable": "^2.3.2",
+        "flatted": "^3.3.3",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
@@ -3080,6 +3137,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3091,6 +3161,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -3157,9 +3234,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3432,13 +3509,6 @@
         }
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3467,13 +3537,13 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kind-of": {
@@ -3487,9 +3557,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5020,6 +5090,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/qified": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5507,9 +5590,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.12.0.tgz",
-      "integrity": "sha512-F8zZ3L/rBpuoBZRvI4JVT20ZanPLXfQLzMOZg1tzPflRVh9mKpOZ8qcSIhh1my3FjAjZWG4T2POwGnmn6a6hbg==",
+      "version": "16.26.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+      "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
       "dev": true,
       "funding": [
         {
@@ -5523,41 +5606,42 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/media-query-list-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
         "@csstools/selector-specificity": "^5.0.0",
-        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "@dual-bundle/import-meta-resolve": "^4.2.1",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
         "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.1",
-        "debug": "^4.3.7",
-        "fast-glob": "^3.3.2",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^9.1.0",
+        "file-entry-cache": "^11.1.1",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.3.1",
-        "ignore": "^6.0.2",
+        "ignore": "^7.0.5",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.35.0",
+        "known-css-properties": "^0.37.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^13.2.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.6",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.0.0",
+        "postcss-selector-parser": "^7.1.0",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
-        "supports-hyperlinks": "^3.1.0",
+        "supports-hyperlinks": "^3.2.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
         "write-file-atomic": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.6.5",
     "serve": "^14.2.5",
-    "stylelint": "^16.12.0",
+    "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1",
     "vitest": "^4.0.18"
   },

--- a/scripts/generate-deps-report.cjs
+++ b/scripts/generate-deps-report.cjs
@@ -1,0 +1,99 @@
+const fs = require('fs');
+
+const audit = JSON.parse(fs.readFileSync('artifacts/npm-audit.json', 'utf8'));
+const outdated = JSON.parse(fs.readFileSync('artifacts/npm-outdated.json', 'utf8'));
+
+let report = `# Dependency Report - ${new Date().toISOString().split('T')[0]}\n\n`;
+
+report += `## Vulnerabilities\n`;
+const severities = { critical: [], high: [], moderate: [], low: [], info: [] };
+
+if (audit.vulnerabilities) {
+  for (const [pkg, details] of Object.entries(audit.vulnerabilities)) {
+    if (severities[details.severity]) {
+      severities[details.severity].push({ pkg, ...details });
+    }
+  }
+}
+
+for (const sev of ['critical', 'high', 'moderate', 'low', 'info']) {
+  if (severities[sev].length > 0) {
+    report += `### ${sev.toUpperCase()} (${severities[sev].length})\n`;
+    severities[sev].forEach(v => {
+      // Process 'via' array
+      let viaStr = '';
+      if (Array.isArray(v.via)) {
+        viaStr = v.via.map(item => {
+          if (typeof item === 'string') return item;
+          return item.title || item.name || 'Unknown advisory';
+        }).join(', ');
+      } else {
+        viaStr = String(v.via);
+      }
+
+      report += `- **${v.pkg}**: ${viaStr}\n`;
+      if (sev === 'critical' || sev === 'high') {
+         report += `  - Path: Direct dependency? ${v.isDirect ? 'Yes' : 'No'}\n`;
+         if (v.fixAvailable) {
+            report += `  - Fix Available: ${JSON.stringify(v.fixAvailable)}\n`;
+         }
+      }
+    });
+  }
+}
+
+if (Object.keys(audit.vulnerabilities || {}).length === 0) {
+  report += `No vulnerabilities found.\n`;
+}
+
+
+report += `\n## Outdated Packages\n`;
+const outdatedList = { major: [], minor: [], patch: [] };
+
+for (const [pkg, details] of Object.entries(outdated)) {
+  const current = details.current;
+  const wanted = details.wanted;
+  const latest = details.latest;
+
+  if (!current) continue;
+
+  const type = details.type;
+
+  if (wanted !== current) {
+      const cParts = current.split('.');
+      const wParts = wanted.split('.');
+      if (cParts[0] !== wParts[0]) outdatedList.major.push({ pkg, current, wanted, latest, type });
+      else if (cParts[1] !== wParts[1]) outdatedList.minor.push({ pkg, current, wanted, latest, type });
+      else outdatedList.patch.push({ pkg, current, wanted, latest, type });
+  } else if (latest !== current) {
+      outdatedList.major.push({ pkg, current, wanted, latest, type });
+  }
+}
+
+report += `### Major Updates (Risky)\n`;
+outdatedList.major.forEach(p => report += `- **${p.pkg}** (${p.type}): ${p.current} -> ${p.latest}\n`);
+
+report += `\n### Minor Updates (Safe-ish)\n`;
+outdatedList.minor.forEach(p => report += `- **${p.pkg}** (${p.type}): ${p.current} -> ${p.wanted} (Latest: ${p.latest})\n`);
+
+report += `\n### Patch Updates (Safe)\n`;
+outdatedList.patch.forEach(p => report += `- **${p.pkg}** (${p.type}): ${p.current} -> ${p.wanted}\n`);
+
+
+report += `\n## Triage & Actions\n`;
+if (severities.critical.length > 0) {
+    report += `- [ ] **CRITICAL**: Investigate ${severities.critical.map(v => v.pkg).join(', ')} immediately.\n`;
+}
+if (severities.high.length > 0) {
+    report += `- [ ] **HIGH**: Check for safe upgrades for ${severities.high.map(v => v.pkg).join(', ')}.\n`;
+}
+
+const safeUpgrades = [...outdatedList.patch, ...outdatedList.minor].filter(p => p.type !== 'devDependencies');
+if (safeUpgrades.length > 0) {
+    report += `- [ ] **Safe Candidates**: ${safeUpgrades.map(p => p.pkg).join(', ')}\n`;
+} else {
+    report += `- No safe direct dependency upgrades identified.\n`;
+}
+
+fs.writeFileSync('artifacts/deps-report.md', report);
+console.log('Report generated.');

--- a/test_logs/TEST_LOG_2026-02-20_14-39-21_deps-security-agent.md
+++ b/test_logs/TEST_LOG_2026-02-20_14-39-21_deps-security-agent.md
@@ -1,0 +1,31 @@
+# Test Log
+## Environment
+Node: v22.22.0
+NPM: 11.7.0
+## Install
+
+> bitvid@1.0.0 prepare
+> npm run build:css
+
+
+> bitvid@1.0.0 build:css
+> postcss css/tailwind.source.css -o css/tailwind.generated.css
+
+
+added 427 packages, and audited 428 packages in 13s
+
+110 packages are looking for funding
+  run `npm fund` for details
+
+4 vulnerabilities (1 moderate, 3 high)
+
+To address issues that do not require attention, run:
+  npm audit fix
+
+To address all issues (including breaking changes), run:
+  npm audit fix --force
+
+Run `npm audit` for details.
+## Audit
+Finished Audit.
+## Post-Upgrade Audit

--- a/todo/TODO_2026-02-20_14-39-21_deps-security-agent.md
+++ b/todo/TODO_2026-02-20_14-39-21_deps-security-agent.md
@@ -1,0 +1,5 @@
+## Todo
+- [x] Initial Audit
+- [x] Generate Report
+- [x] Upgrade stylelint
+- [ ] Investigate serve vulnerability


### PR DESCRIPTION
Ran deps-security-agent daily audit.
- Generated artifacts/deps-report.md
- Upgraded stylelint to 16.26.1 (minor dev dependency update)
- Documented vulnerabilities and next steps.

---
*PR created automatically by Jules for task [6971264940035935235](https://jules.google.com/task/6971264940035935235) started by @PR0M3TH3AN*