### PR TITLE
docs(ai): update quickstart and qa (docs-agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ To run **bitvid** locally:
    npm run test:smoke        # Critical path verification
    npm run format
    npm run lint
+   npm run audit             # Design system audit
    ```
 
    _Tip: Use `npm run test:unit` to run the full suite (can be slow)._

--- a/docs/agents/task-logs/daily/2026-02-20_docs-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-20_docs-agent_completed.md
@@ -1,0 +1,23 @@
+# Daily Agent Task: docs-agent
+
+- **Date**: 2026-02-20
+- **Agent**: bitvid-docs-agent
+- **Status**: Completed
+
+## Summary
+
+Audited key documentation files against the codebase and `package.json`.
+
+### Verified
+- `README.md`: Verified commands, quickstart example, and structure.
+- `CONTRIBUTING.md`: Verified commands and links.
+- `docs/nostr-event-schemas.md`: Verified schema definitions against `js/nostrEventSchemas.js`.
+- `docs/playback-fallback.md`: Verified playback logic against `js/services/playbackService.js`.
+- `docs/qa.md`: Verified QA steps.
+
+### Changes
+- **Updated `README.md`**: Added `npm run audit` to the verification steps section to align with `CONTRIBUTING.md` and available scripts.
+- **Updated `docs/qa.md`**: Prioritized `npx serve` over `python -m http.server` as the primary dev server command, consistent with other documentation.
+
+## Next Steps
+- None. Documentation is currently in sync with the codebase.

--- a/docs/qa.md
+++ b/docs/qa.md
@@ -4,7 +4,7 @@ Run this checklist before publishing releases or merging changes that touch uplo
 
 > **Note:** Align every UI styling review with the token-first rules in [`AGENTS.md`](../AGENTS.md) and the [README CSS build pipeline](../README.md#css-build-pipeline). When QA covers styling changes, run `npm run lint:css` (and any related build/test scripts) to catch regressions early.
 
-Before starting, open `docs/kitchen-sink.html` in a browser to review the modal surface reference. Spin up the static dev server (`python -m http.server 8000` or `npx serve`) and load `views/dev/popover-demo.html` to sanity-check overlay menus following [docs/menus.md](./menus.md). With those pages as your visual baseline, perform this quick accessibility spot check in the running app:
+Before starting, open `docs/kitchen-sink.html` in a browser to review the modal surface reference. Spin up the static dev server (`npx serve` or `python -m http.server 8000`) and load `views/dev/popover-demo.html` to sanity-check overlay menus following [docs/menus.md](./menus.md). With those pages as your visual baseline, perform this quick accessibility spot check in the running app:
 
 Automated regression coverage now exercises these flows on the unified design-system variant:
 


### PR DESCRIPTION
Updated `README.md` to include `npm run audit` in the verification steps.
Updated `docs/qa.md` to prioritize `npx serve` over `python -m http.server`.
Audited `CONTRIBUTING.md`, `docs/nostr-event-schemas.md`, `docs/playback-fallback.md` and confirmed accuracy.
Created task log `docs/agents/task-logs/daily/2026-02-20_docs-agent_completed.md`.

---
*PR created automatically by Jules for task [13497406260738575369](https://jules.google.com/task/13497406260738575369) started by @PR0M3TH3AN*