### PR TITLE
Fix profile modal auto-selection when user is logged out

### DIFF
--- a/js/ui/profileModalController.js
+++ b/js/ui/profileModalController.js
@@ -2334,7 +2334,12 @@ export class ProfileModalController {
         (entry) => this.normalizeHexPubkey(entry.pubkey) === normalizedActive,
       );
     }
-    if (!activeEntry && savedEntries.length) {
+    // Only fall back to the first saved profile when an active pubkey IS set
+    // but doesn't match any saved entry (data-inconsistency edge case).
+    // When normalizedActive is null the user is logged out — do NOT auto-select
+    // a profile, otherwise the modal appears as if the user merely switched
+    // accounts instead of logging out.
+    if (!activeEntry && normalizedActive && savedEntries.length) {
       activeEntry = savedEntries[0];
     }
 


### PR DESCRIPTION
## Summary
Fixed a bug where the profile modal would auto-select the first saved profile when a user was logged out, making it appear as though they had merely switched accounts instead of logging out.

## Key Changes
- Added a check for `normalizedActive` being truthy before falling back to the first saved profile
- The fallback now only occurs when an active pubkey IS set but doesn't match any saved entry (data-inconsistency edge case)
- When `normalizedActive` is null (user is logged out), the modal no longer auto-selects a profile

## Implementation Details
The fix distinguishes between two scenarios:
1. **Data inconsistency**: Active pubkey is set but doesn't match any saved entry → fall back to first saved profile
2. **User logged out**: `normalizedActive` is null → do NOT auto-select, preserving the logged-out state in the UI

This prevents the confusing UX where logging out would immediately show a selected profile in the modal.

https://claude.ai/code/session_01Lw3WG8A9Risiqx2uLTZZZH