### PR TITLE
fix(scripts): exclude agent logs from hex linting (agent)

### DIFF
--- a/REMEDIATION_REPORT.md
+++ b/REMEDIATION_REPORT.md
@@ -1,0 +1,32 @@
+# Daily Design System Audit Report (2026-02-22)
+
+Headline: ✓ No violations
+
+## CSS
+Total count: 0
+
+
+## Hex Colors
+Total count: 0
+
+
+## Inline Styles
+Total count: 0
+
+
+## Raw Lengths
+Total count: 0
+
+
+## Bracket Utilities
+Total count: 0
+
+
+## Tailwind Palette
+Total count: 0
+
+
+## Next Steps
+- [ ] Review violations
+- [ ] Apply auto-fixes (if safe)
+- [ ] Open remediation PR

--- a/docs/agents/task-logs/daily/2026-02-22_17-53-17_onboarding-audit-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-22_17-53-17_onboarding-audit-agent_completed.md
@@ -1,0 +1,44 @@
+# Onboarding Audit Report
+
+**Date:** 2026-02-22
+**Status:** ✓ Onboarding passes from clean checkout (with minor lint fix)
+
+## Environment
+- **Node:** v22.22.0
+- **npm:** 11.10.1
+- **OS:** Linux (Sandbox)
+
+## Steps Executed
+1. `npm ci` (Success)
+   - Installed dependencies.
+   - Verified `css/tailwind.generated.css` was created via `prepare` script.
+2. `npx playwright install` (Success)
+   - Installed Chromium, Firefox, WebKit.
+3. `npm run build` (Success)
+   - Built distribution artifacts in `dist/`.
+   - Verified `dist/index.html` exists.
+4. `npm run test:unit:shard1` (Success)
+   - Ran subset of unit tests.
+   - Result: `✔ All unit tests passed`.
+5. `npm run test:smoke` (Success)
+   - Ran smoke tests against local server.
+   - Verified video playback, login, and DM decryption.
+6. `npm run format` (Success)
+   - Formatted code (no changes).
+7. `npm run lint` (Initial Failure -> Fixed -> Success)
+   - Initial failure in `lint:hex` due to false positive in `docs/agents/task-logs/...`.
+   - **Fix:** Updated `scripts/check-hex.js` to exclude `docs/agents/task-logs/**`.
+   - Re-run: Passed.
+8. `npm run audit` (Success)
+   - Design system audit passed.
+
+## Failures & Fixes
+- **Issue:** `npm run lint:hex` flagged a hex-like string (`#2667`) in a previous agent log file.
+- **Root Cause:** The `scripts/check-hex.js` script did not exclude the `docs/agents/task-logs/` directory.
+- **Fix:** Added `docs/agents/task-logs/**` to `IGNORED_GLOBS` in `scripts/check-hex.js`.
+
+## Documentation Updates
+- None required. `README.md` and `CONTRIBUTING.md` accurately reflect the working commands.
+
+## Devcontainer/Docker
+- Not required. Onboarding is robust in the standard environment.

--- a/scripts/check-hex.js
+++ b/scripts/check-hex.js
@@ -40,7 +40,8 @@ const IGNORED_GLOBS = [
   'test_logs/**',
   'context/**',
   'decisions/**',
-  'todo/**'
+  'todo/**',
+  'docs/agents/task-logs/**'
 ];
 
 const gitArgs = [


### PR DESCRIPTION
Executed `onboarding-audit-agent`.

- Validated onboarding steps from `README.md`.
- Identified `npm run lint` failure due to false positive hex color detection in previous agent log files (e.g., `#2667`).
- Fixed `scripts/check-hex.js` to exclude `docs/agents/task-logs/**`.
- Generated onboarding report in `docs/agents/task-logs/daily/`.
- Updated `REMEDIATION_REPORT.md` to reflect clean audit state.

---
*PR created automatically by Jules for task [12406050567777306953](https://jules.google.com/task/12406050567777306953) started by @PR0M3TH3AN*