### PR TITLE
docs(agents): sync scheduler rosters

### DIFF
--- a/docs/agents/task-logs/daily/2026-02-23_17-58-04_scheduler-update-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-23_17-58-04_scheduler-update-agent_completed.md
@@ -1,0 +1,21 @@
+# Agent Execution Log: scheduler-update-agent
+
+**Timestamp:** 2026-02-23_17-58-04
+**Cadence:** daily
+**Agent:** scheduler-update-agent
+**Status:** Success
+
+## Changes
+
+- **Daily Scheduler**: Verified (21 files, 21 roster entries). No changes needed.
+- **Weekly Scheduler**: Verified (16 files, 16 roster entries). No changes needed.
+
+## Verification
+
+- `npm run lint`: Passed.
+- `ls docs/agents/prompts/daily/*.md | wc -l`: 21
+- `ls docs/agents/prompts/weekly/*.md | wc -l`: 16
+
+## Notes
+
+- The scheduler rosters were already in sync with the file system.


### PR DESCRIPTION
Executed `scheduler-update-agent` logic. Verified that both daily and weekly scheduler rosters are in sync with the prompt files on disk. No updates were necessary. Created a completion log.

---
*PR created automatically by Jules for task [6353055378571684254](https://jules.google.com/task/6353055378571684254) started by @PR0M3TH3AN*