### PR TITLE
Add unit tests for js/nostr/utils.js (test-coverage-agent)

### DIFF
--- a/docs/agents/task-logs/weekly/2026-02-25_test-coverage-agent_completed.md
+++ b/docs/agents/task-logs/weekly/2026-02-25_test-coverage-agent_completed.md
@@ -1,0 +1,18 @@
+# Test Coverage Agent: Completed
+
+**Date:** 2026-02-25
+**Agent:** test-coverage-agent
+**Status:** Completed
+
+## Summary
+- Identified `js/nostr/utils.js` as a module with 0% unit test coverage.
+- Implemented `tests/nostr/utils.test.mjs` to cover `getActiveKey` logic (100% coverage for the module).
+- Verified new tests pass locally.
+- Verified full test suite passes.
+
+## Artifacts
+- `tests/nostr/utils.test.mjs` (new file)
+- `artifacts/tests-20260225/unit.log` (test run log)
+
+## Next Steps
+- Continue identifying other low-coverage modules in `js/nostr/` such as `ConnectionManager.js` (requires more complex mocking).

--- a/tests/nostr/utils.test.mjs
+++ b/tests/nostr/utils.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * @file tests/nostr/utils.test.mjs
+ * @description Unit tests for js/nostr/utils.js
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { getActiveKey } from '../../js/nostr/utils.js';
+
+describe('js/nostr/utils.js', () => {
+  describe('getActiveKey', () => {
+    test('returns ROOT key when videoRootId is present', () => {
+      const video = {
+        videoRootId: 'root-123',
+        id: 'note-456',
+        pubkey: 'pk1',
+        tags: [['d', 'd-tag-val']]
+      };
+      const key = getActiveKey(video);
+      assert.strictEqual(key, 'ROOT:root-123');
+    });
+
+    test('returns pubkey:d key when videoRootId is missing but d-tag exists', () => {
+      const video = {
+        id: 'note-456',
+        pubkey: 'pk1',
+        tags: [['d', 'd-tag-val']]
+      };
+      const key = getActiveKey(video);
+      assert.strictEqual(key, 'pk1:d-tag-val');
+    });
+
+    test('returns LEGACY key when videoRootId and d-tag are missing', () => {
+      const video = {
+        id: 'note-456',
+        pubkey: 'pk1',
+        tags: [['t', 'hashtag']]
+      };
+      const key = getActiveKey(video);
+      assert.strictEqual(key, 'LEGACY:note-456');
+    });
+
+    test('handles missing tags array gracefully (returns LEGACY)', () => {
+      const video = {
+        id: 'note-789',
+        pubkey: 'pk2'
+      };
+      const key = getActiveKey(video);
+      assert.strictEqual(key, 'LEGACY:note-789');
+    });
+
+    test('handles empty tags array gracefully (returns LEGACY)', () => {
+        const video = {
+          id: 'note-789',
+          pubkey: 'pk2',
+          tags: []
+        };
+        const key = getActiveKey(video);
+        assert.strictEqual(key, 'LEGACY:note-789');
+      });
+  });
+});


### PR DESCRIPTION
Implemented unit tests for `js/nostr/utils.js` as part of the weekly `test-coverage-agent` task.
Identified that `js/nostr/utils.js` lacked direct unit tests.
Added `tests/nostr/utils.test.mjs` using the project's standard `node:test` runner.
Verified tests pass locally and as part of the full suite.
Created completion log in `docs/agents/task-logs/weekly/`.

---
*PR created automatically by Jules for task [5998265445794573406](https://jules.google.com/task/5998265445794573406) started by @PR0M3TH3AN*