### PR TITLE
fix(test): add wait for logout state in login-flows e2e

### DIFF
--- a/docs/agents/task-logs/daily/2026-02-25_15-15-00_ci-health-agent_completed.md
+++ b/docs/agents/task-logs/daily/2026-02-25_15-15-00_ci-health-agent_completed.md
@@ -1,0 +1,14 @@
+# CI Health Agent - Daily Run (2026-02-25)
+
+## Summary
+- **Investigated Tests**: `tests/nostr/nip07Permissions.test.js` and `tests/nostr/sessionActor.test.js` (flagged as suspicious in prior runs).
+- **Findings**: Tests passed 10/10 times when run with correct environment setup (polyfilled localStorage). No inherent flakiness detected in current environment.
+- **Fixes Applied**:
+  - `tests/e2e/login-flows.spec.ts`: Added `waitForFunction` after programmatic logout to ensure app state is settled before assertion, preventing race conditions (identified via static analysis and memory guidelines).
+
+## Details
+- `tests/nostr/nip07Permissions.test.js` and `tests/nostr/sessionActor.test.js` require `node --import tests/test-helpers/setup-localstorage.mjs` to run correctly in isolation.
+- E2E login flow race condition fixed by waiting for `getAppState().isLoggedIn === false`.
+
+## Next Steps
+- Monitor next CI run to confirm stability of E2E login flows.

--- a/tests/e2e/login-flows.spec.ts
+++ b/tests/e2e/login-flows.spec.ts
@@ -64,6 +64,14 @@ test.describe("Login and authentication flows", () => {
         (window as any).__bitvidTest__.logout();
       });
 
+      // Wait for state to settle
+      await page.waitForFunction(
+        () => {
+          return (window as any).__bitvidTest__.getAppState().isLoggedIn === false;
+        },
+        { timeout: 15000 },
+      );
+
       // Then: state is fully cleared
       const loggedOutState = await page.evaluate(() => {
         return (window as any).__bitvidTest__.getAppState();


### PR DESCRIPTION
Daily CI Health Agent Run:
- Investigated `tests/nostr/nip07Permissions.test.js` and `tests/nostr/sessionActor.test.js` (found robust in isolation).
- Fixed race condition in `tests/e2e/login-flows.spec.ts` where assertion ran before logout state settled.
- Created `docs/agents/task-logs/daily/2026-02-25_15-15-00_ci-health-agent_completed.md`.

---
*PR created automatically by Jules for task [7092880812493571695](https://jules.google.com/task/7092880812493571695) started by @PR0M3TH3AN*