### PR TITLE
🔒 Security Fix: Add rel="noopener noreferrer" to embed watch button

### DIFF
--- a/embed.html
+++ b/embed.html
@@ -96,6 +96,7 @@
               id="embedWatchButton"
               href="#"
               target="_blank"
+              rel="noopener noreferrer"
               class="flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/20 backdrop-blur-md"
             >
               <span>Watch on</span>


### PR DESCRIPTION
* 🎯 **What:** The vulnerability fixed is a missing `rel="noopener noreferrer"` attribute on the "Watch on bitvid" button in `embed.html`.
* ⚠️ **Risk:** The potential impact if left unfixed is Reverse Tabnabbing, where the opened page (target="_blank") can manipulate `window.opener` of the embedding page, potentially leading to phishing or redirection attacks.
* 🛡️ **Solution:** Added `rel="noopener noreferrer"` to the `<a>` tag with `id="embedWatchButton"`.

---
*PR created automatically by Jules for task [9431652007769204320](https://jules.google.com/task/9431652007769204320) started by @PR0M3TH3AN*