### PR TITLE
⚡ Optimize watch history publishing with Promise.all

### DIFF
--- a/js/nostr/watchHistory.js
+++ b/js/nostr/watchHistory.js
@@ -1234,17 +1234,15 @@ class WatchHistoryManager {
 
      const months = Object.keys(records).sort();
 
-     const results = await pMap(
-       months,
-       async (month) => {
+     const results = await Promise.all(
+       months.map(async (month) => {
          const items = records[month];
          // Ideally we check if this month changed before publishing.
          // For now, we rely on the caller or just publish.
          // In a real optimized system we'd track dirty flags per month.
 
          return this.publishMonthRecord(month, items, options);
-       },
-       { concurrency: 5 },
+       }),
      );
 
      for (const res of results) {


### PR DESCRIPTION
💡 **What:** Replaced `pMap` with `Promise.all` in `js/nostr/watchHistory.js` inside `publishRecords` function.

🎯 **Why:** To improve performance of watch history publishing by removing the concurrency limit of 5. The task requested parallelization using `Promise.all`.

📊 **Measured Improvement:**
- Baseline (pMap, concurrency: 5): ~203ms for 10 items (simulated 100ms delay).
- Optimized (Promise.all): ~101ms for 10 items.
- This represents a 2x speedup for this specific test case, and effectively changes behavior from bounded parallelism to fully parallel.

Note: `pMap` import is retained as it is used elsewhere in the file.

---
*PR created automatically by Jules for task [18111087127374532903](https://jules.google.com/task/18111087127374532903) started by @PR0M3TH3AN*