### PR TITLE
Refactor DeleteModal to use shared getDTagValueFromTags utility

### DIFF
--- a/js/ui/components/DeleteModal.js
+++ b/js/ui/components/DeleteModal.js
@@ -1,19 +1,5 @@
+import { getDTagValueFromTags } from "../../nostr/index.js";
 import { createModalAccessibility } from "./modalAccessibility.js";
-
-function extractDTagValue(tags) {
-  if (!Array.isArray(tags)) {
-    return "";
-  }
-  for (const entry of tags) {
-    if (!Array.isArray(entry) || entry.length < 2) {
-      continue;
-    }
-    if (entry[0] === "d" && typeof entry[1] === "string") {
-      return entry[1];
-    }
-  }
-  return "";
-}
 
 export class DeleteModal {
   constructor({
@@ -232,7 +218,7 @@ export class DeleteModal {
       video && typeof video.videoRootId === "string" && video.videoRootId.trim().length
         ? video.videoRootId.trim()
         : "";
-    const dTagValue = extractDTagValue(video?.tags);
+    const dTagValue = getDTagValueFromTags(video?.tags);
 
     if (this.subtitle) {
       const subtitleParts = [];

--- a/tests/ui/components/DeleteModal.test.mjs
+++ b/tests/ui/components/DeleteModal.test.mjs
@@ -1,0 +1,70 @@
+import { test, describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { JSDOM } from "jsdom";
+
+describe("DeleteModal", () => {
+    let DeleteModal;
+    let modal;
+    let mockModalElement;
+    let subtitle;
+    let metadataList;
+
+    beforeEach(async () => {
+        const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+            url: "http://localhost/",
+        });
+        globalThis.document = dom.window.document;
+        globalThis.window = dom.window;
+        globalThis.HTMLElement = dom.window.HTMLElement;
+        globalThis.EventTarget = dom.window.EventTarget;
+        globalThis.Node = dom.window.Node;
+        globalThis.DOMParser = dom.window.DOMParser;
+        globalThis.Event = dom.window.Event;
+        globalThis.CustomEvent = dom.window.CustomEvent;
+
+        // Dynamic import to ensure globals are set before module execution
+        const module = await import("../../../js/ui/components/DeleteModal.js");
+        DeleteModal = module.DeleteModal;
+
+        // Mock DOM elements
+        mockModalElement = document.createElement('div');
+        subtitle = document.createElement('div');
+        subtitle.id = "deleteModalSubtitle";
+        metadataList = document.createElement('dl');
+        metadataList.id = "deleteModalMetadata";
+
+        mockModalElement.appendChild(subtitle);
+        mockModalElement.appendChild(metadataList);
+
+        modal = new DeleteModal();
+        modal.cacheElements(mockModalElement);
+    });
+
+    it("should extract d-tag and display it in subtitle", () => {
+        const video = {
+            tags: [['d', 'my-d-tag']]
+        };
+        modal.setVideo(video);
+
+        assert.ok(subtitle.textContent.includes("d=my-d-tag"), `Subtitle should contain d-tag, got: ${subtitle.textContent}`);
+    });
+
+    it("should extract d-tag and display it in metadata", () => {
+        const video = {
+            tags: [['d', 'my-d-tag']]
+        };
+        modal.setVideo(video);
+
+        const metadataText = metadataList.textContent;
+        assert.ok(metadataText.includes("my-d-tag"), `Metadata should contain d-tag, got: ${metadataText}`);
+    });
+
+     it("should handle missing d-tag", () => {
+        const video = {
+            tags: [['t', 'hashtag']]
+        };
+        modal.setVideo(video);
+
+        assert.ok(!subtitle.textContent.includes("d="), `Subtitle should not contain d-tag, got: ${subtitle.textContent}`);
+    });
+});


### PR DESCRIPTION
This PR refactors `js/ui/components/DeleteModal.js` to remove duplicated logic for extracting the "d" tag from Nostr event tags. It replaces the local `extractDTagValue` function with the shared `getDTagValueFromTags` utility function.

Key changes:
- Removed `extractDTagValue` from `js/ui/components/DeleteModal.js`.
- Imported `getDTagValueFromTags` from `../../nostr/index.js`.
- Updated `setVideo` method to use `getDTagValueFromTags`.
- Added `tests/ui/components/DeleteModal.test.mjs` to verify the behavior and prevent regressions.

The new test file uses `jsdom` to mock the browser environment required by `DeleteModal`.
Verified that `npm run test:unit` passes with the new test file.

---
*PR created automatically by Jules for task [919037621417068012](https://jules.google.com/task/919037621417068012) started by @PR0M3TH3AN*