### PR TITLE
Update watch history test to use aggregated items

### DIFF
--- a/tests/watch-history.test.mjs
+++ b/tests/watch-history.test.mjs
@@ -1591,9 +1591,7 @@ async function testWatchHistoryServiceIntegration() {
       reason: "integration",
     });
     assert.ok(snapshotResult.ok, "snapshot should publish queued pointers");
-    // snapshotResult now contains { items: flatItems, results: [monthResults...] }
-    // or items might be flatItems?
-    const snapshotItems = snapshotResult.items || (snapshotResult.results || []).flatMap(r => r.items || []);
+    const snapshotItems = snapshotResult.items || [];
 
     // Check if item exists first
     const snapshotItem = snapshotItems.find(


### PR DESCRIPTION
Updated `tests/watch-history.test.mjs` to rely on `publishRecords` returning aggregated items, removing unnecessary fallback logic and TODO comments. Verified that `WatchHistoryManager.js` already implements the aggregation logic correctly.

---
*PR created automatically by Jules for task [15094903720553574923](https://jules.google.com/task/15094903720553574923) started by @PR0M3TH3AN*